### PR TITLE
Postgres annotations in sql - merged up to current

### DIFF
--- a/db/loadAnnotations.js
+++ b/db/loadAnnotations.js
@@ -1,6 +1,6 @@
 // Load models
-var db = require('../model/db'),
-	annotations = require('../model/annotations');
+//var db = require('../model/db'),
+	annotations = require('../model/annotations_sql');
 
 // Validate args
 var argv = require('optimist').argv;
@@ -14,11 +14,11 @@ if (!( argv.annotations_file)){
 var path   = require( 'path' ),
 	filepath = path.normalize(__dirname + '/' + argv.annotations_file);
 
-var mongoose = require( 'mongoose' );
+//var mongoose = require( 'mongoose' );
 annotations.loadAnnotationsFromFile( filepath, argv.source, function(err){
 	if (err) throw new Error(err);
 	
 	// Finish up
-	mongoose.disconnect();	
+//	mongoose.disconnect();	
 });
 

--- a/db/loadAnnotations.js
+++ b/db/loadAnnotations.js
@@ -1,6 +1,7 @@
 // Load models
 //var db = require('../model/db'),
 	annotations = require('../model/annotations_sql');
+	pg = require('../model/db_sql');
 
 // Validate args
 var argv = require('optimist').argv;
@@ -14,11 +15,14 @@ if (!( argv.annotations_file)){
 var path   = require( 'path' ),
 	filepath = path.normalize(__dirname + '/' + argv.annotations_file);
 
-//var mongoose = require( 'mongoose' );
-annotations.loadAnnotationsFromFile( filepath, argv.source, function(err){
-	if (err) throw new Error(err);
-	
-	// Finish up
-//	mongoose.disconnect();	
-});
-
+// test connection to postgres
+pg.verify_connection()
+    .then( function () {
+	annotations.loadAnnotationsFromFile( filepath, argv.source, function(err){
+	    if (err) throw new Error(err);	
+	})})
+    .fail( function (err) {
+	console.log("Connection failed:", err);
+	console.log("Check POSTGRES environment variables.");
+	process.exit(1);
+    }).done(); // TODO: rollback?

--- a/model/annotations_schema.js
+++ b/model/annotations_schema.js
@@ -21,23 +21,24 @@ annotations = sql.define({
 	 notNull: true}]	
 })
 aberrations = sql.define({
-    name: 'aberrations',
+    name: 'aber_annos',
     columns: [
 	{name: 'gene', 		dataType: 'varchar(15)', notNull: true},
+	{name: 'cancer',        dataType: 'varchar(40)'},
 	{name: 'transcript',	dataType: 'varchar(20)'}, // not used
 	{name: 'mut_class', 	dataType: 'varchar(15)', notNull: true}, // todo: mutation table and foreign key?
 	{name: 'mut_type',	dataType: 'varchar(35)'},
         {name: 'protein_seq_change', dataType: 'varchar(15)'},
         {name: 'source', 	dataType: 'varchar(20)', notNull: true},
-	{name: 'is_germline',	dataType: 'boolean'}, // not used
-  	{name: 'measurement_type', 	dataType: 'varchar(10)'}, // not used
+//	{name: 'is_germline',	dataType: 'boolean'}, // not used
+//  	{name: 'measurement_type', 	dataType: 'varchar(10)'}, // not used
 	{name: 'comment',	dataType: 'varchar(5000)',},
 	{name: 'anno_type',	dataType: annoTypeName + " DEFAULT 'aber'", notNull:true}, // todo: make this a constraint
 	{name: 'anno_id', dataType: 'integer', primaryKey: true}]
 })
 
 interactions = sql.define({
-    name: 'ppis',
+    name: 'ppi_annos',
     columns: [
 	{name: 'source',	dataType: 'varchar(15)', notNull: true},
 	{name: 'target',	dataType: 'varchar(15)', notNull: true},
@@ -45,7 +46,6 @@ interactions = sql.define({
 	{name: 'type',	 dataType: 'varchar(15)'},
 	{name: 'weight', dataType: 'float'},
 	{name: 'directed',	dataType: 'boolean'},
-	{name: 'reference',	dataType: 'varchar(25)', notNull: true},
 	{name: 'tissue',	dataType: 'varchar(30)'},
 	{name: 'anno_type',	dataType: annoTypeName + " DEFAULT 'ppi'", notNull:true},
 	{name: 'anno_id', dataType: 'integer', primaryKey: true}]

--- a/model/annotations_schema.js
+++ b/model/annotations_schema.js
@@ -1,7 +1,12 @@
 // Import required modules                                                                                                                               
+Database = require('./db_sql');
 var sql = require("sql");
 
 sql.setDialect('postgres')
+
+// type to help link subtypes of annotations
+annoTypeName = "anno_sub_type"
+//annoTypes = ["aber", "ppi"]
 
 // define tables here:
 // todo: enforce uniqueness of secondary (non-null) keys with constraints
@@ -17,8 +22,9 @@ aberrations = sql.define({
 	{name: 'is_germline',	dataType: 'boolean'},
   	{name: 'measurement_type', 	dataType: 'varchar(10)'},
 	{name: 'comment',	dataType: 'varchar(5000)',},
-	{name: 'anno_id', dataType: 'integer', primaryKey: true, 
-	 references: {table:'annos', column: 'u_id'}}]
+	{name: 'anno_type',	dataType: annoTypeName + " DEFAULT 'aber'", notNull:true},
+	{name: 'anno_id', dataType: 'integer', primaryKey: true}]
+    //	 references: {table:'annos', column: 'u_id'}}]
 })
 
 interactions = sql.define({
@@ -32,8 +38,9 @@ interactions = sql.define({
 	{name: 'directed',	dataType: 'boolean'},
 	{name: 'reference',	dataType: 'varchar(25)', notNull: true},
 	{name: 'tissue',	dataType: 'varchar(30)'},
-	{name: 'anno_id', dataType: 'integer', primaryKey: true, 
-	 references: {table:'annos', column: 'u_id'}}]
+	{name: 'anno_type',	dataType: annoTypeName + " DEFAULT 'ppi'", notNull:true},
+	{name: 'anno_id', dataType: 'integer', primaryKey: true}]
+//	 references: {table:'annos', column: 'u_id'}}]
 })
 
 annotations = sql.define({
@@ -42,19 +49,72 @@ annotations = sql.define({
 	{name: 'user_id',       dataType: 'varchar(40)', notNull: true},
 	{name: 'u_id', dataType: 'serial', primaryKey: true},
  	{name: 'reference',	dataType: 'varchar(25)', notNull: true}, 
-	{name: 'type', dataType: 'varchar(15)', notNull: true}]	
+	{name: 'type', dataType: annoTypeName, primaryKey: true, notNull: true}]	
 })
 
 votes = sql.define({
     name: 'votes',
     columns: [
-	{name: 'anno_id', dataType: 'integer', primaryKey: true,
-	 references: {table: 'annos', column: 'u_id'}},
+	{name: 'anno_id', dataType: 'integer', primaryKey: true},
+	{name: 'anno_type',	dataType: annoTypeName, notNull:true},
 	{name: 'user_id', dataType: 'varchar(40)', notNull: true},
 	{name: 'direction', dataType: 'integer', notNull: true},
 	{name: 'comment', dataType: 'varchar(100)'}]
 })
 
 // order matters
+subannos = [aberrations, interactions, votes]
 exports.annotations = annotations
-exports.tables = [aberrations, interactions, votes]
+exports.aberrations = aberrations
+exports.interactions = interactions
+exports.votes = votes
+
+exports.initDatabase = function() {
+    handle_err = function(table, err) {
+	if (err) {
+	    console.log("Error creating", table.getName(), "table:", err)
+	    throw new Error(err)
+	}
+    }
+
+    // create type first - no support for NOT EXISTS/CREATE OR REPLACE 
+    // hence this abomination
+    wholeTypeStr = "DO LANGUAGE plpgsql $$ BEGIN " +
+	"IF NOT EXISTS (select 1 FROM pg_type " +
+	"WHERE typname='" + annoTypeName + "') " + 
+	"THEN CREATE TYPE " + annoTypeName + 
+	" AS ENUM('aber', 'ppi');" + 
+	" END IF; END; $$;"
+
+    Database.sql_query(wholeTypeStr, [], function(err, result) {
+	if (err) {
+	    console.log("Error creating annotation type:", err)
+	    throw new Error(err)
+	} else {
+
+	    // create annotation table, then everything else
+	    annoCreateQuery = annotations.create().ifNotExists()
+	    Database.execute(annoCreateQuery, function(err, result) {
+		handle_err(annotations, err)
+		console.log("SQL Initialized", annotations.getName(), "table");
+
+		// create subannotation and votes table
+		subannos.forEach( function (thisTable) {
+		    createQuery = thisTable.create().ifNotExists() 
+		    Database.execute(createQuery, function(err, result) {
+			handle_err(thisTable, err)
+
+			// link foreign key for subtables of annotations 
+			alterStr = "ALTER TABLE " + thisTable.getName() + 
+			    " ADD FOREIGN KEY ( anno_id, anno_type )" +
+			    " REFERENCES annos ( u_id, type )"
+			Database.sql_query(alterStr, [], function(err, res) {
+			    handle_err(thisTable, err)
+			    console.log("Postgres Initialized", thisTable.getName(), "table");
+			})
+		    })
+		})
+	    })
+	}
+    })
+}

--- a/model/annotations_schema.js
+++ b/model/annotations_schema.js
@@ -25,10 +25,10 @@ aberrations = sql.define({
     columns: [
 	{name: 'gene', 		dataType: 'varchar(15)', notNull: true},
 	{name: 'cancer',        dataType: 'varchar(40)'},
-	{name: 'transcript',	dataType: 'varchar(20)'}, // not used
-	{name: 'mut_class', 	dataType: 'varchar(15)', notNull: true}, // todo: mutation table and foreign key?
+	{name: 'transcript',	dataType: 'varchar(20)'}, 
+	{name: 'mut_class', 	dataType: 'varchar(25)', notNull: true}, // todo: mutation table and foreign key?
 	{name: 'mut_type',	dataType: 'varchar(35)'},
-        {name: 'protein_seq_change', dataType: 'varchar(15)'},
+        {name: 'protein_seq_change', dataType: 'varchar(30)'},
         {name: 'source', 	dataType: 'varchar(20)', notNull: true},
 //	{name: 'is_germline',	dataType: 'boolean'}, // not used
 //  	{name: 'measurement_type', 	dataType: 'varchar(10)'}, // not used

--- a/model/annotations_schema.js
+++ b/model/annotations_schema.js
@@ -55,8 +55,8 @@ votes = sql.define({
     name: 'votes',
     columns: [
 	{name: 'anno_id', dataType: 'integer', primaryKey: true},
-	{name: 'anno_type',	dataType: annoTypeName, notNull:true},
-	{name: 'user_id', dataType: 'varchar(40)', notNull: true},
+	{name: 'anno_type',	dataType: annoTypeName, notNull:true, primaryKey: true},
+	{name: 'voter_id', dataType: 'varchar(40)', notNull: true, primaryKey: true},
 	{name: 'direction', dataType: 'integer', notNull: true},
 	{name: 'comment', dataType: 'varchar(100)'}]
 })

--- a/model/annotations_schema.js
+++ b/model/annotations_schema.js
@@ -1,0 +1,60 @@
+// Import required modules                                                                                                                               
+var sql = require("sql");
+
+sql.setDialect('postgres')
+
+// define tables here:
+// todo: enforce uniqueness of secondary (non-null) keys with constraints
+aberrations = sql.define({
+    name: 'aberrations',
+    columns: [
+	{name: 'gene', 		dataType: 'varchar(15)', notNull: true},
+	{name: 'transcript',	dataType: 'varchar(20)'},
+	{name: 'mut_class', 	dataType: 'varchar(15)', notNull: true},
+	{name: 'mut_type',	dataType: 'varchar(15)'},
+        {name: 'protein_seq_change', dataType: 'varchar(15)'},
+        {name: 'source', 	dataType: 'varchar(20)', notNull: true},
+	{name: 'is_germline',	dataType: 'boolean'},
+  	{name: 'measurement_type', 	dataType: 'varchar(10)'},
+	{name: 'comment',	dataType: 'varchar(5000)',},
+	{name: 'anno_id', dataType: 'integer', primaryKey: true, 
+	 references: {table:'annos', column: 'u_id'}}]
+})
+
+interactions = sql.define({
+    name: 'ppis',
+    columns: [
+	{name: 'source',	dataType: 'varchar(15)', notNull: true},
+	{name: 'target',	dataType: 'varchar(15)', notNull: true},
+	{name: 'database',	dataType: 'varchar(30)'},
+	{name: 'type',	 dataType: 'varchar(15)'},
+	{name: 'weight', dataType: 'float'},
+	{name: 'directed',	dataType: 'boolean'},
+	{name: 'reference',	dataType: 'varchar(25)', notNull: true},
+	{name: 'tissue',	dataType: 'varchar(30)'},
+	{name: 'anno_id', dataType: 'integer', primaryKey: true, 
+	 references: {table:'annos', column: 'u_id'}}]
+})
+
+annotations = sql.define({
+    name: 'annos',
+    columns: [
+	{name: 'user_id',       dataType: 'varchar(40)', notNull: true},
+	{name: 'u_id', dataType: 'serial', primaryKey: true},
+ 	{name: 'reference',	dataType: 'varchar(25)', notNull: true}, 
+	{name: 'type', dataType: 'varchar(15)', notNull: true}]	
+})
+
+votes = sql.define({
+    name: 'votes',
+    columns: [
+	{name: 'anno_id', dataType: 'integer', primaryKey: true,
+	 references: {table: 'annos', column: 'u_id'}},
+	{name: 'user_id', dataType: 'varchar(40)', notNull: true},
+	{name: 'direction', dataType: 'integer', notNull: true},
+	{name: 'comment', dataType: 'varchar(100)'}]
+})
+
+// order matters
+exports.annotations = annotations
+exports.tables = [aberrations, interactions, votes]

--- a/model/annotations_schema.js
+++ b/model/annotations_schema.js
@@ -57,7 +57,8 @@ votes = sql.define({
 	{name: 'anno_id', dataType: 'integer', primaryKey: true},
 	{name: 'anno_type',	dataType: annoTypeName, notNull:true, primaryKey: true},
 	{name: 'voter_id', dataType: 'varchar(40)', notNull: true, primaryKey: true},
-	{name: 'direction', dataType: 'integer', notNull: true},
+	{name: 'upvote', dataType: 'smallint', notNull: true},  // integrity check: only one vote at a time
+	{name: 'downvote', dataType: 'smallint', notNull: true},
 	{name: 'comment', dataType: 'varchar(100)'}]
 })
 

--- a/model/annotations_schema.js
+++ b/model/annotations_schema.js
@@ -57,8 +57,10 @@ votes = sql.define({
 	{name: 'anno_id', dataType: 'integer', primaryKey: true},
 	{name: 'anno_type',	dataType: annoTypeName, notNull:true, primaryKey: true},
 	{name: 'voter_id', dataType: 'varchar(40)', notNull: true, primaryKey: true},
-	{name: 'upvote', dataType: 'smallint', notNull: true},  // integrity check: only one vote at a time
-	{name: 'downvote', dataType: 'smallint', notNull: true},
+	// integrity check: only one vote at a time
+	{name: 'direction', dataType: 'smallint', notNull: true},
+//	{name: 'upvote', dataType: 'smallint', notNull: true},  
+//	{name: 'downvote', dataType: 'smallint', notNull: true},
 	{name: 'comment', dataType: 'varchar(100)'}]
 })
 

--- a/model/annotations_schema.js
+++ b/model/annotations_schema.js
@@ -25,8 +25,8 @@ aberrations = sql.define({
     columns: [
 	{name: 'gene', 		dataType: 'varchar(15)', notNull: true},
 	{name: 'transcript',	dataType: 'varchar(20)'}, // not used
-	{name: 'mut_class', 	dataType: 'varchar(15)', notNull: true},
-	{name: 'mut_type',	dataType: 'varchar(15)'},
+	{name: 'mut_class', 	dataType: 'varchar(15)', notNull: true}, // todo: mutation table and foreign key?
+	{name: 'mut_type',	dataType: 'varchar(35)'},
         {name: 'protein_seq_change', dataType: 'varchar(15)'},
         {name: 'source', 	dataType: 'varchar(20)', notNull: true},
 	{name: 'is_germline',	dataType: 'boolean'}, // not used

--- a/model/annotations_sql.js
+++ b/model/annotations_sql.js
@@ -132,6 +132,7 @@ exports.upsert = function(data, callback){
 	aberInsertQuery = abers.insert(
 	    abers.gene.value(data.gene),
 	    abers.cancer.value(data.cancer),
+	    abers.transcript.value(data.transcript),
 	    abers.mut_class.value(data.mut_class),
 	    abers.mut_type.value(data.mut_type),
 	    abers.protein_seq_change.value(data.change),
@@ -194,7 +195,7 @@ exports.loadAnnotationsFromFile = function(filename, source, callback){
 	    }
 	    annotations.push( support );
 	}
-	console.log( "Loaded " + annotations.length + " annotations." )
+	console.log( "Loading " + annotations.length + " annotations from file..." )
 
 	// Save all the annotations
 	return Q.allSettled( annotations.map(function(A){
@@ -202,8 +203,9 @@ exports.loadAnnotationsFromFile = function(filename, source, callback){
 
 	    var query = {
 		gene: A.gene,
-//		cancer: A.cancer,
+		cancer: A.cancer,
 		change: A.change,
+		transcript: A.transcript,
 		mut_class: A.mutation_class,
 		mut_type: A.mutation_type,
 		pmid: A.reference,
@@ -213,7 +215,6 @@ exports.loadAnnotationsFromFile = function(filename, source, callback){
 	    };
 
 	    exports.upsert(query, function(err, annotation){
-		console.log("in callback: err=", err, ", anno=",annotation)
 		if (err) throw new Error(err);
 		d.resolve();
 	    })

--- a/model/annotations_sql.js
+++ b/model/annotations_sql.js
@@ -10,30 +10,85 @@ exports.init = Schemas.initDatabase
 exports.geneFind = function(query, callback /*(err, results) */) {
     abers = Schemas.aberrations
     annos = Schemas.annotations
-    console.log("query in geneFind: ", query)
-    selQuery = abers.where(query).from(abers.join(annos).join(votes))
+    votes = Schemas.votes
 
+    console.log("query in geneFind: ", query)
+
+    // todo: update $2 depending on how many args are passed in
+    voteSubQueryText = 
+	" (SELECT U.anno_id, upvotes, downvotes FROM " +
+	" (SELECT anno_id, array_agg(voter_id) AS upvotes " +
+	" FROM votes WHERE upvote = 1 group by anno_id)" +
+	" AS U JOIN " +                          
+	" (SELECT anno_id, array_agg(voter_id) AS downvotes FROM votes " +
+	" WHERE downvote = 1 group by anno_id) as D " +
+	" ON U.anno_id = D.anno_id) "
+   
+    selAnnosQuery = abers
+//	.select(
+     	// annos.u_id, 
+     	// annos.reference,
+     	// abers.gene,
+     	// abers.mut_class,
+     	// abers.mut_type,
+     	// abers.protein_seq_change)
+	.from(abers.join(annos).on(abers.anno_id.equals(annos.u_id)))
+	.where(query)
+
+    selQuerySplit = selAnnosQuery.toQuery().text.split("WHERE")
+
+    wholeQueryText = selQuerySplit[0] + " LEFT JOIN " + 
+	voteSubQueryText + " AS vote_ballots  " + 
+	" ON vote_ballots.anno_id = annos.u_id WHERE " +
+	selQuerySplit[1]
     // todo: fill out references, and up/down votes
-    Database.execute(selQuery, function(err, result) {
+    console.log("WHOLE QUERY:", wholeQueryText)
+
+    Database.sql_query(wholeQueryText, selAnnosQuery.toQuery().values, function(err, result) {
 	if (err) {
             console.log("Error selecting gene annotations: " + err);
 	    console.log("Debug: full query:", selQuery.string) 
-	    callback(err, null)
+	    callback(err, null)	    
 	} 
+	
 	callback(null, result.rows)
     })
 }
 
 // todo: Vote for a mutation
 exports.vote = function mutationVote(fields, user_id){
-    annos = Schemas.annotations
     votes = Schemas.votes
 
-/*    annoInsertQuery = annos.insert([{
-	user_id : data.user_id,
-	reference : data.pmid,
-	type : "aber" }]).returning(annos.u_id)
-    */
+    // Set up the promise
+    var Q = require( 'q' ),
+    d = Q.defer();
+
+    //Create and execute the query
+    var anno_id = fields.annotation_id, // FIXME: not guaranteed unique - better to use anno_id,
+    valence;
+
+    // todo: change existing vote if necessary
+    if (fields.vote == "up") {
+	valence = 1 
+    } else if (fields.vote == "down") {
+	valence = -1
+    }
+
+    voteQuery = votes.insert(votes.voter_id.value(user_id),
+		 votes.direction.value(valence),
+		 votes.anno_type.value("aber"),
+		 votes.u_id.value(anno_id))
+    Database.execute(voteQuery, function (err, result) {
+	// Throw error and resolve if necessary
+	if (err){
+	    console.log("Error voting for mutation:", err)
+	    throw new Error(err);
+	}
+	console.log("User", user_id, "voted for anno #",  anno_id);
+	d.resolve();
+    })
+
+    return d.promise;
 }
 
 // upsert an aberration annotation into SQL                              

--- a/model/annotations_sql.js
+++ b/model/annotations_sql.js
@@ -68,11 +68,12 @@ exports.getAnnotations = function (genes, callback) {
 exports.upsert = function(anno, callback){
     // todo: prepared statements                                                                                                                             
     // don't need this unpacking step, but requires persistent client                                                                                        
+    
+    query = aberrations.insert(aberrations.gene.value(anno.gene),
+ 		aberrations.mut_class.value(anno.mutation_class))
 
-    unpacked = [anno.gene, anno.mut_class, anno.reference, anno.source, anno.user_id];
-    query_str = 'INSERT INTO aberrations (gene, mut_class, reference, source, user_id) VALUES ($1, $2, $3, $4, $5)';
     console.log("upserting ", anno.gene);
-    sql_result = Database.sql_query(query_str, unpacked, function(err, result) {
+    sql_result = Database.execute(query, function(err, result) {
         if (err) {
             console.log("Error upserting gene annotation: " + err);
             return //FIXME - where should errors be handled?                                                                                                 

--- a/model/annotations_sql.js
+++ b/model/annotations_sql.js
@@ -7,12 +7,33 @@ var sql = require("sql");
 exports.init = Schemas.initDatabase
 
 // find all annotations given a structure with regexp
-exports.find = function(query, callback /*(err, results) */) {
-    
+exports.geneFind = function(query, callback /*(err, results) */) {
+    abers = Schemas.aberrations
+    annos = Schemas.annotations
+    console.log("query in geneFind: ", query)
+    selQuery = abers.where(query).from(abers.join(annos).join(votes))
+
+    // todo: fill out references, and up/down votes
+    Database.execute(selQuery, function(err, result) {
+	if (err) {
+            console.log("Error selecting gene annotations: " + err);
+	    console.log("Debug: full query:", selQuery.string) 
+	    callback(err, null)
+	} 
+	callback(null, result.rows)
+    })
 }
 
 // todo: Vote for a mutation
 exports.vote = function mutationVote(fields, user_id){
+    annos = Schemas.annotations
+    votes = Schemas.votes
+
+/*    annoInsertQuery = annos.insert([{
+	user_id : data.user_id,
+	reference : data.pmid,
+	type : "aber" }]).returning(annos.u_id)
+    */
 }
 
 // upsert an aberration annotation into SQL                              

--- a/model/annotations_sql.js
+++ b/model/annotations_sql.js
@@ -5,28 +5,8 @@ var sql = require("sql");
 
 //initialize table
 tables = Schemas.tables
-exports.init = function() {
-    handle_err = function(table, err) {
-	    if (!err) {
-		console.log("SQL Initialized", table.getName(), "table in postgres");
-	    } else {
-		console.log("Error creating", table.getName(), "table:", err)
-		throw new Error(err)
-	    }
-    }
 
-    // create annotation table, then everything else
-    anno_create = Schemas.annotations.create().ifNotExists()
-    Database.execute(anno_create, function(err, result) {
-	handle_err(Schemas.annotations, err)
-	tables.forEach(function (thisTable) {
-	    table_create = thisTable.create().ifNotExists() 
-	    Database.execute(table_create, function(err, result) {
-		handle_err(thisTable, err)
-	    })
-	})
-    })
-}
+exports.init = Schemas.initDatabase
 
 exports.dumpAll = function(callback){
     aberrations = tables.aberrations
@@ -60,7 +40,7 @@ exports.getAnnotations = function (genes, callback) {
     });
 };
 
-// upsert an aberration annotation into MongoDB                                                                                                              
+// upsert an aberration annotation into SQL                              
 exports.upsert = function(anno, callback){
     aberrations = tables.aberrations
     // todo: prepared statements                                                                                                                                query = aberrations.insert(aberrations.gene.value(anno.gene))

--- a/model/annotations_sql.js
+++ b/model/annotations_sql.js
@@ -1,0 +1,99 @@
+// Import required modules                                                                                                                                   
+Database = require('./db_sql');
+
+//                                                                                                                                                           
+// initialize table                                                                                                                                          
+
+exports.init = function() {
+    Database.sql_query("CREATE TABLE IF NOT EXISTS aberrations " +
+              "(gene varchar(15), " + //ref gene table?                                                                                                      
+              "transcript varchar(20), " +
+              "mut_class varchar(15), " + // ref a small table 
+              "mut_type varchar(15), " + // ref a small table                                                                                                
+              "protein_seq_change varchar(15), " +
+              "reference varchar(25), " +
+              "source varchar(20), " +
+              "is_germline boolean, " +
+              "measurement_type varchar(10), " +
+              "comment varchar(5000), " +
+              "user_id varchar(20));", [],  // key is gene, mut_class, ref, source, user_id?                                                       
+		function(err, result) {
+			if (!err) {
+				console.log("Initialized aberrations table in postgres");
+			}
+		});		
+}
+
+exports.dumpAll = function(callback){
+    Database.sql_query('SELECT gene, mut_class, reference, source, user_id FROM aberrations', [],
+                 function(err, result) {
+                     if (err) {
+                         console.log("Error dumping gene annotation table: " + err);
+                         return
+                     }
+                     pkg_result = {
+                         rows: result.rows
+                     };
+                     callback(null, pkg_result)
+                 });
+};
+
+exports.getAnnotations = function (genes, callback) {
+	console.log("in model:", genes)
+	query = "SELECT gene, mut_class, reference, source, user_id FROM aberrations " +
+		"WHERE gene IN $1 ORDER BY gene;"
+	Database.sql_query(query, genes, function(err, result) {
+		if (err) {
+			console.log("Error getting annotations for specific genes");
+			return
+		}
+		pkg_result = {
+			rows:result.rows
+		};
+		callback(null, pkg_result);
+	});
+};
+
+// upsert an aberration annotation into MongoDB                                                                                                              
+exports.upsert = function(anno, callback){
+    // todo: prepared statements                                                                                                                             
+    // don't need this unpacking step, but requires persistent client                                                                                        
+
+    unpacked = [anno.gene, anno.mut_class, anno.reference, anno.source, anno.user_id];
+    query_str = 'INSERT INTO aberrations (gene, mut_class, reference, source, user_id) VALUES ($1, $2, $3, $4, $5)';
+    console.log("upserting ", anno.gene);
+    sql_result = Database.sql_query(query_str, unpacked, function(err, result) {
+        if (err) {
+            console.log("Error upserting gene annotation: " + err);
+            return //FIXME - where should errors be handled?                                                                                                 
+        }                                                                                                                                                    
+        callback(null, result) // what is result of upsert?                                                                                                  
+    }); // check status                                                                                                                                      
+}
+
+/*
+// Vote for a mutation                                                                                                                                       
+exports.vote = function mutationVote(fields, user_id){
+}
+// Loads annotations into the database                                                                                                                       
+exports.loadAnnotationsFromFile = function(filename, source, callback){
+}
+//                                                                                                                                                           
+exports.geneTable = function (genes, support){
+    // Assemble the annotations into a dictionary index by                                                                                                   
+    // gene (e.g. TP53) and mutation class (e.g. missense or amp)                                                                                                // and then protein change (only applicable for missense/nonsense)                                                                                       
+    // 1) Store the total number of references for the gene/class in "",                                                                                     
+    // i.e. annotations['TP53'][''] gives the total for TP53 and                                                                                             
+    // annotations['TP53']['snv'][''] gives the total for TP53 SNVs.                                                                                         
+    // 2) Count the number per protein change.                                                                                                               
+    // Combine references at the PMID level so that for each                                                                                                 
+    // annotation type (gene, type, locus) we have a list of references                                                                                      
+    // with {pmid: String, cancers: Array }. Then collapse at the cancer type(s)                                                                             
+    // level so we have a list of PMIDs that all map to the same cancer type(s)                                                                              
+    function combineCancers(objects){
+        });
+    });
+    return annotations;
+}
+
+*/

--- a/model/annotations_sql.js
+++ b/model/annotations_sql.js
@@ -1,94 +1,84 @@
-// Import required modules                                                                                                                                   
+// Import required modules                                                                                                                               
 Database = require('./db_sql');
+Schemas = require('./annotations_schema.js');
 var sql = require("sql");
 
-sql.setDialect('postgres')
-                                                                                                                                                           
-// define tables here:
-// initialize table                                                                                                                                          
-
-// todo: make sure the primary keys make sense
-var aberrations = sql.define({
-	name: 'aberrations',
-	columns: [
-		{name: 'gene', 		dataType: 'varchar(15)', notNull: true, primaryKey: true},
-		{name: 'transcript',	dataType: 'varchar(20)'},
-		{name: 'mut_class', 	dataType: 'varchar(15)', notNull: true, primaryKey: true},
-		{name: 'mut_type',	dataType: 'varchar(15)'},
-         	{name: 'protein_seq_change', dataType: 'varchar(15)'},
- 		{name: 'reference',	dataType: 'varchar(25)', notNull: true, primaryKey: true}, 
-                {name: 'source', 	dataType: 'varchar(20)', notNull: true},
-		{name: 'is_germline',	dataType: 'boolean'},
-  		{name: 'measurement_type', 	dataType: 'varchar(10)'},
-		{name: 'comment',	dataType: 'varchar(5000)',},
-  		{name: 'user_id',	dataType: 'varchar(100)', notNull: true, primaryKey: true}]
-});
-
+//initialize table
+tables = Schemas.tables
 exports.init = function() {
-    	query = aberrations.create().ifNotExists()
-	Database.execute(query,
-		function(err, result) {
-			if (!err) {
-				console.log("Initialized aberrations table in postgres");
-			} else {
-				console.log("Error creating aberrations table: ", err)
-				throw new Error(err)
-			}
-		});		
+    handle_err = function(table, err) {
+	    if (!err) {
+		console.log("SQL Initialized", table.getName(), "table in postgres");
+	    } else {
+		console.log("Error creating", table.getName(), "table:", err)
+		throw new Error(err)
+	    }
+    }
+
+    // create annotation table, then everything else
+    anno_create = Schemas.annotations.create().ifNotExists()
+    Database.execute(anno_create, function(err, result) {
+	handle_err(Schemas.annotations, err)
+	tables.forEach(function (thisTable) {
+	    table_create = thisTable.create().ifNotExists() 
+	    Database.execute(table_create, function(err, result) {
+		handle_err(thisTable, err)
+	    })
+	})
+    })
 }
 
 exports.dumpAll = function(callback){
-	query = aberrations.select(aberrations.gene).select(aberrations.mut_class)
-    Database.execute(query,
-                 function(err, result) {
-                     if (err) {
-                         console.log("Error dumping gene annotation table: " + err);
-                         return
-                     }
-                     pkg_result = {
-                         rows: result.rows
-                     };
-                     callback(null, pkg_result)
-                 });
+    aberrations = tables.aberrations
+    query = aberrations.select(aberrations.gene).select(aberrations.mut_class)
+    Database.execute(query, function(err, result) {
+	if (err) {
+	    console.log("Error dumping gene annotation table: " + err);
+	    return
+	}
+	pkg_result = {
+	    rows: result.rows
+	};
+	callback(null, pkg_result)
+    });
 };
 
 exports.getAnnotations = function (genes, callback) {
-	console.log("in model:", genes)
-	query = aberrations.where(aberrations.gene.in(genes)).select(aberrations.gene).select(aberrations.mut_class)
-	Database.execute(query, function(err, result) {
-		if (err) {
-			console.log("Error getting annotations for specific genes");
-			console.log(err)
-			return
-		}
-		pkg_result = {
-			rows:result.rows
-		};
-		callback(null, pkg_result);
-	});
+    aberrations = tables.aberrations
+    console.log("in model:", genes)
+    query = aberrations.where(aberrations.gene.in(genes)).select(aberrations.gene).select(aberrations.mut_class)
+    Database.execute(query, function(err, result) {
+	if (err) {
+	    console.log("Error getting annotations for specific genes");
+	    console.log(err)
+	    return
+	}
+	pkg_result = {
+	    rows:result.rows
+	};
+	callback(null, pkg_result);
+    });
 };
 
 // upsert an aberration annotation into MongoDB                                                                                                              
 exports.upsert = function(anno, callback){
-    // todo: prepared statements                                                                                                                             
-    // don't need this unpacking step, but requires persistent client                                                                                        
-    
-    query = aberrations.insert(
-		aberrations.gene.value(anno.gene),
- 		aberrations.mut_class.value(anno.mutation_class),
-		aberrations.reference.value(anno.pmid),
-		aberrations.source.value(anno.source),
-		aberrations.user_id.value(anno.user_id))
+    aberrations = tables.aberrations
+    // todo: prepared statements                                                                                                                                query = aberrations.insert(aberrations.gene.value(anno.gene))
+//    aberrations.mut_class.value(anno.mutation_class),
+//    aberrations.reference.value(anno.pmid),
+//    aberrations.source.value(anno.source),
+//    aberrations.user_id.value(anno.user_id))
 
-    console.log("upserting ", anno.gene);
-    sql_result = Database.execute(query, function(err, result) {
-        if (err) {
-            console.log("Error upserting gene annotation: " + err);
-		console.log("full query:", query.string) 
-	        callback(err, null)
-        }                                                                                                                                                    
-        callback(null, result) // what is result of upsert?                                                                                                  
-    }); // check status                                                                                                                                      
+console.log("upserting ", anno.gene);
+sql_result = Database.execute(query, function(err, result) {
+    if (err) {
+        console.log("Error upserting gene annotation: " + err);
+	console.log("full query:", query.string) 
+	callback(err, null)
+    }                                                                                                                                                    
+    callback(null, result) // what is result of upsert?                                                                                                  
+}); // check status                                                                                                                                      
+
 }
 
 /*
@@ -100,20 +90,20 @@ exports.loadAnnotationsFromFile = function(filename, source, callback){
 }
 //                                                                                                                                                           
 exports.geneTable = function (genes, support){
-    // Assemble the annotations into a dictionary index by                                                                                                   
-    // gene (e.g. TP53) and mutation class (e.g. missense or amp)                                                                                                // and then protein change (only applicable for missense/nonsense)                                                                                       
-    // 1) Store the total number of references for the gene/class in "",                                                                                     
-    // i.e. annotations['TP53'][''] gives the total for TP53 and                                                                                             
-    // annotations['TP53']['snv'][''] gives the total for TP53 SNVs.                                                                                         
-    // 2) Count the number per protein change.                                                                                                               
-    // Combine references at the PMID level so that for each                                                                                                 
-    // annotation type (gene, type, locus) we have a list of references                                                                                      
-    // with {pmid: String, cancers: Array }. Then collapse at the cancer type(s)                                                                             
-    // level so we have a list of PMIDs that all map to the same cancer type(s)                                                                              
-    function combineCancers(objects){
-        });
-    });
-    return annotations;
+// Assemble the annotations into a dictionary index by                                                                                                   
+// gene (e.g. TP53) and mutation class (e.g. missense or amp)                                                                                                // and then protein change (only applicable for missense/nonsense)                                                                                       
+// 1) Store the total number of references for the gene/class in "",                                                                                     
+// i.e. annotations['TP53'][''] gives the total for TP53 and                                                                                             
+// annotations['TP53']['snv'][''] gives the total for TP53 SNVs.                                                                                         
+// 2) Count the number per protein change.                                                                                                               
+// Combine references at the PMID level so that for each                                                                                                 
+// annotation type (gene, type, locus) we have a list of references                                                                                      
+// with {pmid: String, cancers: Array }. Then collapse at the cancer type(s)                                                                             
+// level so we have a list of PMIDs that all map to the same cancer type(s)                                                                              
+function combineCancers(objects){
+});
+});
+return annotations;
 }
 
 */

--- a/model/annotations_sql.js
+++ b/model/annotations_sql.js
@@ -23,6 +23,10 @@ exports.dumpAll = function(callback){
     });
 };
 
+// todo: Vote for a mutation
+exports.vote = function mutationVote(fields, user_id){
+}
+
 exports.getAnnotations = function (genes, callback) {
     aberrations = tables.aberrations
     console.log("in model:", genes)
@@ -61,29 +65,29 @@ sql_result = Database.execute(query, function(err, result) {
 
 }
 
-/*
-// Vote for a mutation                                                                                                                                       
-exports.vote = function mutationVote(fields, user_id){
-}
-// Loads annotations into the database                                                                                                                       
+// todo:  Loads annotations into the database
 exports.loadAnnotationsFromFile = function(filename, source, callback){
 }
-//                                                                                                                                                           
+                                                                                                                                                          // todo: assemble annotations 
 exports.geneTable = function (genes, support){
-// Assemble the annotations into a dictionary index by                                                                                                   
-// gene (e.g. TP53) and mutation class (e.g. missense or amp)                                                                                                // and then protein change (only applicable for missense/nonsense)                                                                                       
-// 1) Store the total number of references for the gene/class in "",                                                                                     
-// i.e. annotations['TP53'][''] gives the total for TP53 and                                                                                             
-// annotations['TP53']['snv'][''] gives the total for TP53 SNVs.                                                                                         
-// 2) Count the number per protein change.                                                                                                               
-// Combine references at the PMID level so that for each                                                                                                 
-// annotation type (gene, type, locus) we have a list of references                                                                                      
-// with {pmid: String, cancers: Array }. Then collapse at the cancer type(s)                                                                             
-// level so we have a list of PMIDs that all map to the same cancer type(s)                                                                              
-function combineCancers(objects){
-});
-});
-return annotations;
+    // Assemble the annotations into a dictionary index by                                                                                                   
+    // gene (e.g. TP53) and mutation class (e.g. missense or amp)                                                                                                // and then protein change (only applicable for missense/nonsense)                                                                                       
+    // 1) Store the total number of references for the gene/class in "",                                                                                     
+    // i.e. annotations['TP53'][''] gives the total for TP53 and                                                                                             
+    // annotations['TP53']['snv'][''] gives the total for TP53 SNVs.                                                                                         
+    // 2) Count the number per protein change.                                                                                                               
+    // Combine references at the PMID level so that for each                                                                                                 
+    // annotation type (gene, type, locus) we have a list of references                                                                                      
+    // with {pmid: String, cancers: Array }. Then collapse at the cancer type(s)                                                                             
+    // level so we have a list of PMIDs that all map to the same cancer type(s)  
+
+    // todo: subfunction                                                         	// Combine references at the PMID level so that for each 
+    // annotation type (gene, type, locus) we have a list of references
+    // with {pmid: String, cancers: Array }. Then collapse at the cancer type(s)
+    // level so we have a list of PMIDs that all map to the same cancer type(s)
+    
+    function combineCancers(objects){
+    }
+//return annotations;
 }
 
-*/

--- a/model/db_sql.js
+++ b/model/db_sql.js
@@ -1,0 +1,18 @@
+var pg = require("pg");
+
+var conString = 'postgres://postgres@' + process.env.POSTGRES_PORT_5432_TCP_ADDR + ':5432/';
+
+exports.sql_query = function sql_query(text, values, cb){
+    // gets a client from the client pool                                                                                                                    
+    pg.connect(conString, function(err, client, done) {
+        if(err) {
+            return console.error('error fetching client from pool', err);
+        }
+
+        query = client.query(text, values, function(err, result) {
+            done(); // releases the client back to the pool                                                                                                  
+            cb(err, result);
+        });
+    })
+}
+

--- a/model/db_sql.js
+++ b/model/db_sql.js
@@ -7,6 +7,8 @@ console.log('connection:', conString);
 exports.execute = execute
 exports.executeAppend = executeAppend
 exports.sql_query = sql_query
+
+
 //  a query built by SQL package
 function execute(query, cb){
     q = query.toQuery()
@@ -26,11 +28,11 @@ function executeAppend(query, suffix, cb){
     }
 }
 
-// a straight parametrized query
+// a straight parametrized query that uses the client pool
 function sql_query(text, values, cb){
     // gets a client from the client pool                  
-    console.log("plaintext query is:", text)
-    console.log("plaintext values are:", values)
+//    console.log("plaintext query is:", text)
+//    console.log("plaintext values are:", values)
     pg.connect(conString, function(err, client, done) {
         if(err) {
             return console.error('error fetching client from pool', err);

--- a/model/db_sql.js
+++ b/model/db_sql.js
@@ -1,19 +1,35 @@
 var pg = require("pg");
 var conString = 'postgres://postgres@' + process.env.POSTGRES_HOST + ':' + 
-process.env.POSTGRES_PORT + '/magi';
+    process.env.POSTGRES_PORT + '/magi';
 
 console.log('connection:', conString);
-exports.execute = execute
-exports.sql_query = sql_query
 
+exports.execute = execute
+exports.executeAppend = executeAppend
+exports.sql_query = sql_query
+//  a query built by SQL package
 function execute(query, cb){
-	q = query.toQuery()
-	sql_query(q.text, q.values, cb)
+    q = query.toQuery()
+    sql_query(q.text, q.values, cb)
 }
 
+// a query built by SQL package, with an extra modifier appended
+function executeAppend(query, suffix, cb){
+    q = query.toQuery()
+    cmd = q.text.split(" ", 1)[0]
+    
+    if (cmd.toUpperCase() == "CREATE") {
+	fullCmd = q.text.slice(0,q.text.length - 1) + ", " + suffix + ")"
+	sql_query(fullCmd, q.values, cb)
+    } else {
+	sql_query(q.text + suffix, q.values, cb)
+    }
+}
+
+// a straight parametrized query
 function sql_query(text, values, cb){
     // gets a client from the client pool                  
-//    console.log(text)
+//    console.log("plaintext query is:", text)
     pg.connect(conString, function(err, client, done) {
         if(err) {
             return console.error('error fetching client from pool', err);
@@ -24,3 +40,7 @@ function sql_query(text, values, cb){
         });
     })
 }
+
+// todo: add transactions
+
+// todo: support client model

--- a/model/db_sql.js
+++ b/model/db_sql.js
@@ -13,6 +13,7 @@ function execute(query, cb){
 
 function sql_query(text, values, cb){
     // gets a client from the client pool                  
+//    console.log(text)
     pg.connect(conString, function(err, client, done) {
         if(err) {
             return console.error('error fetching client from pool', err);

--- a/model/db_sql.js
+++ b/model/db_sql.js
@@ -1,6 +1,8 @@
 var pg = require("pg");
-var conString = 'postgres://postgres@' + process.env.POSTGRES_PORT_5432_TCP_ADDR + ':5432/';
+var conString = 'postgres://postgres@' + process.env.POSTGRES_HOST + ':' + 
+process.env.POSTGRES_PORT + '/magi';
 
+console.log('connection:', conString);
 exports.execute = execute
 exports.sql_query = sql_query
 
@@ -11,7 +13,6 @@ function execute(query, cb){
 
 function sql_query(text, values, cb){
     // gets a client from the client pool                  
-    console.log("text = ", text, ", values = ", values)
     pg.connect(conString, function(err, client, done) {
         if(err) {
             return console.error('error fetching client from pool', err);

--- a/model/db_sql.js
+++ b/model/db_sql.js
@@ -29,7 +29,8 @@ function executeAppend(query, suffix, cb){
 // a straight parametrized query
 function sql_query(text, values, cb){
     // gets a client from the client pool                  
-//    console.log("plaintext query is:", text)
+    console.log("plaintext query is:", text)
+    console.log("plaintext values are:", values)
     pg.connect(conString, function(err, client, done) {
         if(err) {
             return console.error('error fetching client from pool', err);

--- a/model/db_sql.js
+++ b/model/db_sql.js
@@ -1,18 +1,24 @@
 var pg = require("pg");
-
 var conString = 'postgres://postgres@' + process.env.POSTGRES_PORT_5432_TCP_ADDR + ':5432/';
 
-exports.sql_query = function sql_query(text, values, cb){
-    // gets a client from the client pool                                                                                                                    
+exports.execute = execute
+exports.sql_query = sql_query
+
+function execute(query, cb){
+	q = query.toQuery()
+	sql_query(q.text, q.values, cb)
+}
+
+function sql_query(text, values, cb){
+    // gets a client from the client pool                  
+    console.log("text = ", text, ", values = ", values)
     pg.connect(conString, function(err, client, done) {
         if(err) {
             return console.error('error fetching client from pool', err);
         }
-
         query = client.query(text, values, function(err, result) {
             done(); // releases the client back to the pool                                                                                                  
             cb(err, result);
         });
     })
 }
-

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "moment": "latest",
     "jsdom": "3.x",
     "q": "latest",
-    "request": "latest"
+    "request": "latest",
+    "pg": "latest"
   },
   "repository": {
     "type": "git"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "jsdom": "3.x",
     "q": "latest",
     "request": "latest",
-    "pg": "latest"
+    "pg": "latest",
+    "sql": "latest"
   },
   "repository": {
     "type": "git"

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -17,6 +17,7 @@ exports.getAll = function gene(req, res) {
     });
 }
 
+// todo: add post route to add genes
 // Renders annotations for the given gene
 exports.gene = function gene(req, res){
 	console.log('/annotations/gene_sql');
@@ -25,10 +26,15 @@ exports.gene = function gene(req, res){
 	var gene = req.params.gene.toUpperCase() || ""
 //		Annotation = Database.magi.model( 'Annotation' ),
 //		Cancer = Database.magi.model( 'Cancer' );
-
-	annotations.dump(gene, function(err, result) {
+	annotations.getAnnotations([gene], function(err, result) {
 		if(!err) {
 			res.render('annotations/blanktable', result);
 		}
 	});
+}
+
+exports.addAnnotation = function gene(req, res) {
+	console.log('/annotations/add_gene')
+	
+	// 
 }

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -59,6 +59,7 @@ exports.saveMutation = function saveMutation(req, res) {
 	var query = {
 	    gene: req.body.gene,
 	    cancer: req.body.cancer, 
+	    transcript: req.body.transcript,
 	    mut_class: req.body.mutationClass,
 	    mut_type: req.body.mutationType,
 	    protein_seq_change: req.body.change,

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -83,3 +83,26 @@ exports.saveMutation = function saveMutation(req, res) {
     }
     // 
 }
+
+// Save a vote on a mutation
+exports.mutationVote = function mutationVote(req, res){
+    // Only allow logged in users to vote
+    if (req.isAuthenticated()){
+	if (!req.body){
+	    res.send({error: 'Empty vote body.'})
+	    return;
+	}
+
+	// Add the annotation, forcing the user ID to be a string to make finding it in arrays easy
+	Annotations.vote(req.body, req.user._id + "")
+	    .then(function(){
+		res.send({ status: "Mutation vote saved successfully!" });
+	    })
+	    .fail(function(){
+		res.send({ error: "Mutation vote could not be parsed." });
+	    });
+    }
+    else{
+	res.send({ error: "You must be logged in to vote." });
+    }
+}

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -1,9 +1,9 @@
 // Load required modules
 var	mongoose = require( 'mongoose' ),
-	formidable = require('formidable'),
-	annotations  = require( "../model/annotations_sql" ),
-	PPIs = require( "../model/ppis" ),
-	Database = require('../model/db_sql');
+formidable = require('formidable'),
+annotations  = require( "../model/annotations_sql" ),
+PPIs = require( "../model/ppis" ),
+Database = require('../model/db_sql');
 
 // Create the table if it doesn't exist already
 annotations.init()
@@ -12,7 +12,7 @@ annotations.init()
 exports.getAll = function gene(req, res) {
     annotations.dumpAll(function(err, result) {
 	if(!err) {
-	        res.render('annotations/blanktable', result);
+	    res.render('annotations/blanktable', result);
 	}	
     });
 }
@@ -20,56 +20,56 @@ exports.getAll = function gene(req, res) {
 // todo: add post route to add genes
 // Renders annotations for the given gene
 exports.gene = function gene(req, res){
-	console.log('/annotations/gene_sql');
+    console.log('/annotations/gene_sql');
 
-	// Parse params
-	var gene = req.params.gene.toUpperCase() || ""
-//		Annotation = Database.magi.model( 'Annotation' ),
-//		Cancer = Database.magi.model( 'Cancer' );
-	annotations.getAnnotations([gene], function(err, result) {
-		if(!err) {
-			res.render('annotations/blanktable', result);
-		}
-	});
+    // Parse params
+    var gene = req.params.gene.toUpperCase() || ""
+    //		Annotation = Database.magi.model( 'Annotation' ),
+    //		Cancer = Database.magi.model( 'Cancer' );
+    annotations.getAnnotations([gene], function(err, result) {
+	if(!err) {
+	    res.render('annotations/blanktable', result);
+	}
+    });
 }
 
 exports.addAnnotation = function gene(req, res) {
-	console.log('/annotations/gene_sql/add')
-	console.log('req:', req)
-	console.log('req.body:', req.body)
-	
-	console.log("proxy for: /save/annotation/mutation")
+    console.log('/annotations/gene_sql/add')
+    console.log('req:', req)
+    console.log('req.body:', req.body)
+    
+    console.log("proxy for: /save/annotation/mutation")
 
-	// Load the posted form
-	var form = new formidable.IncomingForm({});
+    // Load the posted form
+    var form = new formidable.IncomingForm({});
 
-	// We ignore this if the user isn't logged in
-	if (req.user && req.body){
-		// Add the annotation
-		var query = {
-				gene: req.body.gene,
-				cancer: req.body.cancer,
-				mutation_class: req.body.mutationClass,
-				mutation_type: req.body.mutationType,
-				change: req.body.change,
-				domain: req.body.domain,
-				pmid: req.body.pmid,
-				comment: req.body.comment,
-				user_id: req.user._id,
-				source: "Community"
-			};
+    // We ignore this if the user isn't logged in
+    if (req.user && req.body){
+	// Add the annotation
+	var query = {
+	    gene: req.body.gene,
+	    cancer: req.body.cancer,
+	    mutation_class: req.body.mutationClass,
+	    mutation_type: req.body.mutationType,
+	    change: req.body.change,
+	    domain: req.body.domain,
+	    pmid: req.body.pmid,
+	    comment: req.body.comment,
+	    user_id: req.user._id,
+	    source: "Community"
+	};
 
-		annotations.upsert(query, function(err, annotation){
-			if (err){
-				res.send({ error: "Annotation could not be parsed. " + err });
-				// todo: handle error: interpret or pass up if critical (no database, no table)
-				throw new Error(err);
-			}
-			res.send({ status: "Annotation saved successfully!", annotation: { _id: annotation._id } });
-		});
-	}
-	else{
-		res.send({ error: "You must be logged in to annotate." });
-	}
-	// 
+	annotations.upsert(query, function(err, annotation){
+	    if (err){
+		res.send({ error: "Annotation could not be parsed. " + err });
+		// todo: handle error: interpret or pass up if critical (no database, no table)
+		throw new Error(err);
+	    }
+	    res.send({ status: "Annotation saved successfully!", annotation: { _id: annotation._id } });
+	});
+    }
+    else{
+	res.send({ error: "You must be logged in to annotate." });
+    }
+    // 
 }

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -33,13 +33,9 @@ exports.gene = function gene(req, res){
     });
 }
 
-exports.addAnnotation = function gene(req, res) {
-    console.log('/annotations/gene_sql/add')
-    console.log('req:', req)
-    console.log('req.body:', req.body)
+exports.saveMutation = function saveMutation(req, res) {
+    console.log('/annotations/gene_sql/add ("proxy for: /save/annotation/mutation")')
     
-    console.log("proxy for: /save/annotation/mutation")
-
     // Load the posted form
     var form = new formidable.IncomingForm({});
 
@@ -48,11 +44,11 @@ exports.addAnnotation = function gene(req, res) {
 	// Add the annotation
 	var query = {
 	    gene: req.body.gene,
-	    cancer: req.body.cancer,
+	    cancer: req.body.cancer, // not used
 	    mutation_class: req.body.mutationClass,
 	    mutation_type: req.body.mutationType,
 	    change: req.body.change,
-	    domain: req.body.domain,
+	    domain: req.body.domain, // not used
 	    pmid: req.body.pmid,
 	    comment: req.body.comment,
 	    user_id: req.user._id,
@@ -65,7 +61,7 @@ exports.addAnnotation = function gene(req, res) {
 		// todo: handle error: interpret or pass up if critical (no database, no table)
 		throw new Error(err);
 	    }
-	    res.send({ status: "Annotation saved successfully!", annotation: { _id: annotation._id } });
+	    res.send({ status: "Annotation saved successfully!", annotation: { _id: annotation.u_id } });
 	});
     }
     else{

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -34,7 +34,41 @@ exports.gene = function gene(req, res){
 }
 
 exports.addAnnotation = function gene(req, res) {
-	console.log('/annotations/add_gene')
+	console.log('/annotations/gene_sql/add')
+	console.log('req:', req)
+	console.log('req.body:', req.body)
 	
+	console.log("proxy for: /save/annotation/mutation")
+
+	// Load the posted form
+	var form = new formidable.IncomingForm({});
+
+	// We ignore this if the user isn't logged in
+	if (req.user && req.body){
+		// Add the annotation
+		var query = {
+				gene: req.body.gene,
+				cancer: req.body.cancer,
+				mutation_class: req.body.mutationClass,
+				mutation_type: req.body.mutationType,
+				change: req.body.change,
+				domain: req.body.domain,
+				pmid: req.body.pmid,
+				comment: req.body.comment,
+				user_id: req.user._id,
+				source: "Community"
+			};
+
+		annotations.upsert(query, function(err, annotation){
+			if (err){
+				res.send({ error: "Annotation could not be parsed. " + err });
+				throw new Error(err);
+			}
+			res.send({ status: "Annotation saved successfully!", annotation: { _id: annotation._id } });
+		});
+	}
+	else{
+		res.send({ error: "You must be logged in to annotate." });
+	}
 	// 
 }

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -1,0 +1,34 @@
+// Load required modules
+var	mongoose = require( 'mongoose' ),
+	formidable = require('formidable'),
+	annotations  = require( "../model/annotations_sql" ),
+	PPIs = require( "../model/ppis" ),
+	Database = require('../model/db_sql');
+
+// Create the table if it doesn't exist already
+annotations.init()
+
+// Renders annotations for the whole table:
+exports.getAll = function gene(req, res) {
+    annotations.dumpAll(function(err, result) {
+	if(!err) {
+	        res.render('annotations/blanktable', result);
+	}	
+    });
+}
+
+// Renders annotations for the given gene
+exports.gene = function gene(req, res){
+	console.log('/annotations/gene_sql');
+
+	// Parse params
+	var gene = req.params.gene.toUpperCase() || ""
+//		Annotation = Database.magi.model( 'Annotation' ),
+//		Cancer = Database.magi.model( 'Cancer' );
+
+	annotations.dump(gene, function(err, result) {
+		if(!err) {
+			res.render('annotations/blanktable', result);
+		}
+	});
+}

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -58,10 +58,10 @@ exports.saveMutation = function saveMutation(req, res) {
 	// Add the annotation
 	var query = {
 	    gene: req.body.gene,
-	    cancer: req.body.cancer, // not used
-	    mutation_class: req.body.mutationClass,
-	    mutation_type: req.body.mutationType,
-	    change: req.body.change,
+	    cancer: req.body.cancer, 
+	    mut_class: req.body.mutationClass,
+	    mut_type: req.body.mutationType,
+	    protein_seq_change: req.body.change,
 	    domain: req.body.domain, // not used
 	    pmid: req.body.pmid,
 	    comment: req.body.comment,
@@ -106,3 +106,22 @@ exports.mutationVote = function mutationVote(req, res){
 	res.send({ error: "You must be logged in to vote." });
     }
 }
+
+// Renders annotations for the given cancer
+exports.cancer = function cancer(req, res){
+    // todo: this route how
+	console.log('/annotations/cancer');
+
+	// Parse params
+	var cancer = req.params.cancer.split("-").join(" ") || "",
+		Annotation = Database.magi.model( 'Annotation' );
+
+	annotation.geneFind({cancer: { $regex : new RegExp('^' + cancer + '$', 'i') }}, function(err, annotations){
+		// Throw error (if necessary)
+		if (err) throw new Error(err);
+
+		// Render the view
+		res.render('annotations/cancer', { user: req.user, annotations: annotations, cancer: cancer });
+	});
+}
+

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -62,6 +62,7 @@ exports.addAnnotation = function gene(req, res) {
 		annotations.upsert(query, function(err, annotation){
 			if (err){
 				res.send({ error: "Annotation could not be parsed. " + err });
+				// todo: handle error: interpret or pass up if critical (no database, no table)
 				throw new Error(err);
 			}
 			res.send({ status: "Annotation saved successfully!", annotation: { _id: annotation._id } });

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -94,7 +94,7 @@ exports.mutationVote = function mutationVote(req, res){
 	}
 
 	// Add the annotation, forcing the user ID to be a string to make finding it in arrays easy
-	Annotations.vote(req.body, req.user._id + "")
+	annotations.vote(req.body, req.user._id + "")
 	    .then(function(){
 		res.send({ status: "Mutation vote saved successfully!" });
 	    })

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -34,9 +34,6 @@ exports.gene = function gene(req, res){
 	// Throw error (if necessary)
 	if (err) throw new Error(err);
 
-	// todo: check what annotations should look like on return and change render page
-	console.log("annotations returned: ", result)
-
 	// Render the view
 	var pkg = {
 	    user: req.user,

--- a/routes/annotations_sql.js
+++ b/routes/annotations_sql.js
@@ -61,6 +61,10 @@ exports.saveMutation = function saveMutation(req, res) {
 	    req.body.cancer.toLowerCase() in cancerToAbbr) {
 	    req.body.cancer = cancerToAbbr[req.body.cancer.toLowerCase()];
 	}
+
+	// more direct?
+//	query = req.body;
+
 	var query = {
 	    gene: req.body.gene,
 	    cancer: req.body.cancer, 
@@ -76,7 +80,7 @@ exports.saveMutation = function saveMutation(req, res) {
 	};
 
 	// TODO: test behavior on attempting to upsert identical annotation?
-	annotations.upsert(query, function(err, annotation){
+	annotations.upsertAber(query, function(err, annotation){
 	    if (err){
 		res.send({ error: "Annotation could not be parsed. " + err });
 		// todo: handle error: interpret or pass up if critical (no database, no table)
@@ -133,3 +137,23 @@ exports.cancer = function cancer(req, res){
 	});
 }
 
+exports.savePPI = function savePPI(req, res){
+	console.log("sql proxy for: /save/annotation/ppi")
+
+	if (req.user && req.body){
+	    /* fields already in req.body: source, target, pmid, comment */
+	    query = req.body;
+	    query.anno_source = "Community"
+	    query.user_id = req.user._id + ""
+	    annotations.upsertPPI(query, function(err, annotation){
+		if (err) {
+		    res.send({ error: "Interaction could not be parsed." });
+		    throw new Error(err)
+		}
+		res.send({ status: "Interaction saved successfully!" , annotation: { _id: annotation.u_id }});	    
+	    })
+	} else {
+	    res.send({ error: "You must be logged in to annotate." });
+	}
+	return;
+}

--- a/routes/router.js
+++ b/routes/router.js
@@ -92,13 +92,10 @@ exports.queryGetDatasetsAndGenes = requery.queryGetDatasetsAndGenes;
 // test routes for POSTGRESQL
 exports.annotations_SQL = {};
 exports.annotations_SQL.saveMutation = annotations_SQL.saveMutation
-<<<<<<< HEAD
-exports.annotations_SQL.gene = annotations_SQL.gene;
-
-=======
 exports.annotations_SQL.gene = annotations_SQL.gene
 exports.annotations_SQL.mutationVote = annotations_SQL.mutationVote;
->>>>>>> wrote query for counting annotations; modified gene annotations view for flat answer
+exports.annotations_SQL.cancer = annotations_SQL.cancer
+
 // exports.annotations.cancer = annotations.cancer;
 // exports.annotations.save.mutation = annotations.saveMutation;
 // exports.annotations.save.ppi = annotations.savePPI;

--- a/routes/router.js
+++ b/routes/router.js
@@ -91,7 +91,12 @@ exports.queryGetDatasetsAndGenes = requery.queryGetDatasetsAndGenes;
 
 // test routes for POSTGRESQL
 exports.annotations_SQL = {};
-exports.annotations_SQL.all = annotations_SQL.getAll;
 exports.annotations_SQL.saveMutation = annotations_SQL.saveMutation
 exports.annotations_SQL.gene = annotations_SQL.gene;
->>>>>>> starting minimal postgres hook for annotations, parallel routes for testing access to annotations in postgres
+
+// exports.annotations.cancer = annotations.cancer;
+// exports.annotations.save.mutation = annotations.saveMutation;
+// exports.annotations.save.ppi = annotations.savePPI;
+// exports.annotations.ppiVote = annotations.ppiVote;
+// exports.annotations.ppiComment = annotations.ppiComment;
+// exports.annotations.mutationVote = annotations.mutationVote;

--- a/routes/router.js
+++ b/routes/router.js
@@ -8,6 +8,7 @@ var about = require( './about' ),
 	enrichments = require( './enrichments' ),
 	datasets = require('./datasets'),
 	annotations = require('./annotations'),
+	annotations_SQL = require('./annotations_sql'),
   log = require('./log'),
   share = require('./share'),
   requery = require('./requery');
@@ -84,5 +85,12 @@ exports.isLoggingEnabled = log.isLoggingEnabled;
 exports.logConsent = log.logConsent;
 exports.userGaveConsent = log.userGaveConsent;
 
+
 // Requery parameters
 exports.queryGetDatasetsAndGenes = requery.queryGetDatasetsAndGenes;
+
+// test routes for POSTGRESQL
+exports.annotations_SQL = {};
+exports.annotations_SQL.all = annotations_SQL.getAll;
+exports.annotations_SQL.gene = annotations_SQL.gene;
+>>>>>>> starting minimal postgres hook for annotations, parallel routes for testing access to annotations in postgres

--- a/routes/router.js
+++ b/routes/router.js
@@ -92,8 +92,13 @@ exports.queryGetDatasetsAndGenes = requery.queryGetDatasetsAndGenes;
 // test routes for POSTGRESQL
 exports.annotations_SQL = {};
 exports.annotations_SQL.saveMutation = annotations_SQL.saveMutation
+<<<<<<< HEAD
 exports.annotations_SQL.gene = annotations_SQL.gene;
 
+=======
+exports.annotations_SQL.gene = annotations_SQL.gene
+exports.annotations_SQL.mutationVote = annotations_SQL.mutationVote;
+>>>>>>> wrote query for counting annotations; modified gene annotations view for flat answer
 // exports.annotations.cancer = annotations.cancer;
 // exports.annotations.save.mutation = annotations.saveMutation;
 // exports.annotations.save.ppi = annotations.savePPI;

--- a/routes/router.js
+++ b/routes/router.js
@@ -92,6 +92,6 @@ exports.queryGetDatasetsAndGenes = requery.queryGetDatasetsAndGenes;
 // test routes for POSTGRESQL
 exports.annotations_SQL = {};
 exports.annotations_SQL.all = annotations_SQL.getAll;
-exports.annotations_SQL.addAnnotation = annotations_SQL.addAnnotation
+exports.annotations_SQL.saveMutation = annotations_SQL.saveMutation
 exports.annotations_SQL.gene = annotations_SQL.gene;
 >>>>>>> starting minimal postgres hook for annotations, parallel routes for testing access to annotations in postgres

--- a/routes/router.js
+++ b/routes/router.js
@@ -91,14 +91,13 @@ exports.queryGetDatasetsAndGenes = requery.queryGetDatasetsAndGenes;
 
 // test routes for POSTGRESQL
 exports.annotations_SQL = {};
-exports.annotations_SQL.saveMutation = annotations_SQL.saveMutation
-exports.annotations_SQL.gene = annotations_SQL.gene
+exports.annotations_SQL.saveMutation = annotations_SQL.saveMutation;
+exports.annotations_SQL.gene = annotations_SQL.gene;
 exports.annotations_SQL.mutationVote = annotations_SQL.mutationVote;
-exports.annotations_SQL.cancer = annotations_SQL.cancer
+exports.annotations_SQL.cancer = annotations_SQL.cancer;
+exports.annotations_SQL.save_ppi = annotations_SQL.savePPI;
 
 // exports.annotations.cancer = annotations.cancer;
-// exports.annotations.save.mutation = annotations.saveMutation;
-// exports.annotations.save.ppi = annotations.savePPI;
 // exports.annotations.ppiVote = annotations.ppiVote;
 // exports.annotations.ppiComment = annotations.ppiComment;
-// exports.annotations.mutationVote = annotations.mutationVote;
+// mutation comment?

--- a/routes/router.js
+++ b/routes/router.js
@@ -92,5 +92,6 @@ exports.queryGetDatasetsAndGenes = requery.queryGetDatasetsAndGenes;
 // test routes for POSTGRESQL
 exports.annotations_SQL = {};
 exports.annotations_SQL.all = annotations_SQL.getAll;
+exports.annotations_SQL.addAnnotation = annotations_SQL.addAnnotation
 exports.annotations_SQL.gene = annotations_SQL.gene;
 >>>>>>> starting minimal postgres hook for annotations, parallel routes for testing access to annotations in postgres

--- a/server.js
+++ b/server.js
@@ -176,7 +176,7 @@ app.get('/manifests', routes.datasets.manifests);
 //app.get('/annotations/gene/:gene', routes.annotations.gene);
 app.get('/annotations/cancer/:cancer', routes.annotations.cancer);
 //app.post('/save/annotation/mutation', ensureAuthenticated, routes.annotations.save.mutation);
-app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);
+//app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);
 app.post('/vote/ppi', ensureAuthenticated, routes.annotations.ppiVote);
 app.post('/comment/ppi', ensureAuthenticated, routes.annotations.ppiComment);
 //app.post('/vote/mutation', routes.annotations.mutationVote);
@@ -186,6 +186,7 @@ app.get('/annotations/gene/:gene', routes.annotations_SQL.gene);
 //app.get('/annotations/cancer/:cancer', routes.annotations_SQL.cancer);
 app.post('/save/annotation/mutation/', ensureAuthenticated, routes.annotations_SQL.saveMutation);
 app.post('/vote/mutation', routes.annotations_SQL.mutationVote);
+app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations_SQL.save_ppi);
 
 // more information
 app.get('/terms', routes.terms);

--- a/server.js
+++ b/server.js
@@ -173,7 +173,7 @@ app.get('/datasets/view/:datasetID', routes.datasets.view);
 app.get('/manifests', routes.datasets.manifests);
 
 // Annotation views
-app.get('/annotations/gene/:gene', routes.annotations.gene);
+//app.get('/annotations/gene/:gene', routes.annotations.gene);
 app.get('/annotations/cancer/:cancer', routes.annotations.cancer);
 //app.post('/save/annotation/mutation', ensureAuthenticated, routes.annotations.save.mutation);
 app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);
@@ -182,9 +182,9 @@ app.post('/comment/ppi', ensureAuthenticated, routes.annotations.ppiComment);
 app.post('/vote/mutation', routes.annotations.mutationVote);
 
 // SQL subtitute annotation views
-app.get('/annotations/gene_sql_dump/', routes.annotations_SQL.all);
-app.get('/annotations/gene_sql/:gene', routes.annotations_SQL.gene);
+app.get('/annotations/gene/:gene', routes.annotations_SQL.gene);
 app.post('/save/annotation/mutation/', ensureAuthenticated, routes.annotations_SQL.saveMutation);
+
 //app.get('/annotations/cancer/:cancer', routes.annotations.cancer);
 //app.post('/save/annotation/mutation', ensureAuthenticated, routes.annotations.save.mutation);
 //app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);

--- a/server.js
+++ b/server.js
@@ -179,18 +179,12 @@ app.get('/annotations/cancer/:cancer', routes.annotations.cancer);
 app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);
 app.post('/vote/ppi', ensureAuthenticated, routes.annotations.ppiVote);
 app.post('/comment/ppi', ensureAuthenticated, routes.annotations.ppiComment);
-app.post('/vote/mutation', routes.annotations.mutationVote);
+//app.post('/vote/mutation', routes.annotations.mutationVote);
 
 // SQL subtitute annotation views
 app.get('/annotations/gene/:gene', routes.annotations_SQL.gene);
 app.post('/save/annotation/mutation/', ensureAuthenticated, routes.annotations_SQL.saveMutation);
-
-//app.get('/annotations/cancer/:cancer', routes.annotations.cancer);
-//app.post('/save/annotation/mutation', ensureAuthenticated, routes.annotations.save.mutation);
-//app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);
-//app.post('/vote/ppi', ensureAuthenticated, routes.annotations.ppiVote);
-//app.post('/comment/ppi', ensureAuthenticated, routes.annotations.ppiComment);
-//app.post('/vote/mutation', routes.annotations.mutationVote);
+app.post('/vote/mutation', routes.annotations_SQL.mutationVote);
 
 // more information
 app.get('/terms', routes.terms);

--- a/server.js
+++ b/server.js
@@ -181,6 +181,16 @@ app.post('/vote/ppi', ensureAuthenticated, routes.annotations.ppiVote);
 app.post('/comment/ppi', ensureAuthenticated, routes.annotations.ppiComment);
 app.post('/vote/mutation', routes.annotations.mutationVote);
 
+// SQL subtitute annotation views
+app.get('/annotations/gene_sql_dump/', routes.annotations_SQL.all);
+app.get('/annotations/gene_sql/:gene', routes.annotations_SQL.gene);
+//app.get('/annotations/cancer/:cancer', routes.annotations.cancer);
+//app.post('/save/annotation/mutation', ensureAuthenticated, routes.annotations.save.mutation);
+//app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);
+//app.post('/vote/ppi', ensureAuthenticated, routes.annotations.ppiVote);
+//app.post('/comment/ppi', ensureAuthenticated, routes.annotations.ppiComment);
+//app.post('/vote/mutation', routes.annotations.mutationVote);
+
 // more information
 app.get('/terms', routes.terms);
 app.get('/contact', routes.contact);

--- a/server.js
+++ b/server.js
@@ -175,7 +175,7 @@ app.get('/manifests', routes.datasets.manifests);
 // Annotation views
 app.get('/annotations/gene/:gene', routes.annotations.gene);
 app.get('/annotations/cancer/:cancer', routes.annotations.cancer);
-app.post('/save/annotation/mutation', ensureAuthenticated, routes.annotations.save.mutation);
+//app.post('/save/annotation/mutation', ensureAuthenticated, routes.annotations.save.mutation);
 app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);
 app.post('/vote/ppi', ensureAuthenticated, routes.annotations.ppiVote);
 app.post('/comment/ppi', ensureAuthenticated, routes.annotations.ppiComment);
@@ -184,7 +184,7 @@ app.post('/vote/mutation', routes.annotations.mutationVote);
 // SQL subtitute annotation views
 app.get('/annotations/gene_sql_dump/', routes.annotations_SQL.all);
 app.get('/annotations/gene_sql/:gene', routes.annotations_SQL.gene);
-app.post('/annotations/gene_sql/add:anno', routes.annotations_SQL.addAnnotation);
+app.post('/save/annotation/mutation/', ensureAuthenticated, routes.annotations_SQL.addAnnotation);
 //app.get('/annotations/cancer/:cancer', routes.annotations.cancer);
 //app.post('/save/annotation/mutation', ensureAuthenticated, routes.annotations.save.mutation);
 //app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);

--- a/server.js
+++ b/server.js
@@ -183,6 +183,7 @@ app.post('/comment/ppi', ensureAuthenticated, routes.annotations.ppiComment);
 
 // SQL subtitute annotation views
 app.get('/annotations/gene/:gene', routes.annotations_SQL.gene);
+//app.get('/annotations/cancer/:cancer', routes.annotations_SQL.cancer);
 app.post('/save/annotation/mutation/', ensureAuthenticated, routes.annotations_SQL.saveMutation);
 app.post('/vote/mutation', routes.annotations_SQL.mutationVote);
 

--- a/server.js
+++ b/server.js
@@ -184,7 +184,7 @@ app.post('/vote/mutation', routes.annotations.mutationVote);
 // SQL subtitute annotation views
 app.get('/annotations/gene_sql_dump/', routes.annotations_SQL.all);
 app.get('/annotations/gene_sql/:gene', routes.annotations_SQL.gene);
-app.post('/save/annotation/mutation/', ensureAuthenticated, routes.annotations_SQL.addAnnotation);
+app.post('/save/annotation/mutation/', ensureAuthenticated, routes.annotations_SQL.saveMutation);
 //app.get('/annotations/cancer/:cancer', routes.annotations.cancer);
 //app.post('/save/annotation/mutation', ensureAuthenticated, routes.annotations.save.mutation);
 //app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);

--- a/server.js
+++ b/server.js
@@ -184,6 +184,7 @@ app.post('/vote/mutation', routes.annotations.mutationVote);
 // SQL subtitute annotation views
 app.get('/annotations/gene_sql_dump/', routes.annotations_SQL.all);
 app.get('/annotations/gene_sql/:gene', routes.annotations_SQL.gene);
+app.post('/annotations/gene_sql/add:anno', routes.annotations_SQL.addAnnotation);
 //app.get('/annotations/cancer/:cancer', routes.annotations.cancer);
 //app.post('/save/annotation/mutation', ensureAuthenticated, routes.annotations.save.mutation);
 //app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save.ppi);

--- a/views/annotations/blanktable.jade
+++ b/views/annotations/blanktable.jade
@@ -1,0 +1,9 @@
+html
+  table
+    thead
+    tbody
+      for row in rows
+        tr
+        for obj in row
+          td= obj
+

--- a/views/annotations/gene.jade
+++ b/views/annotations/gene.jade
@@ -69,24 +69,23 @@ block body
 					- var mutationClass = d.mutation_class ? d.mutation_class : "--";
 					- var mutationType = d.mutation_type ? d.mutation_type : "--";
 					- var proteinSeqChange = d.change ? d.change : "--";
-					- for (var j = 0; j < d.references.length; j++)
-						- var ref = d.references[j];
-						- var numVotes = ref.upvotes.length - ref.downvotes.length;
-						- var downVoteClass = ref.downvotes.indexOf(user_id) === -1 ? "" : "downvote-on";
-						- var upVoteClass = ref.upvotes.indexOf(user_id) === -1 ? "" : "upvote-on";
-						tr
-							td !{cancer} 
-							td #{mutation_class(mutationClass)}
-							td #{mutation_type(mutationType)}
-							td #{proteinSeqChange}
-							td !{pubmedLink(ref.pmid)}
-							td !{ref.source}
-							td
-								- if (user_id != "")
-									a(href="#", class="downvote #{downVoteClass}", annotation-id="#{d._id}", pmid="#{ref.pmid}") &#x25BC;&nbsp;
-								span(id="vote-#{d._id}-#{ref.pmid}") #{numVotes}
-								- if (user_id != "")
-									a(href="#", class="upvote  #{upVoteClass}", annotation-id="#{d._id}", pmid="#{ref.pmid}") &#x25B2;
+
+					- var numVotes = d.upvotes.length - d.downvotes.length;
+					- var pmid_ref = d.reference
+					- var downVoteClass = d.downvotes.indexOf(user_id) === -1 ? "" : "downvote-on";
+					- var upVoteClass = d.upvotes.indexOf(user_id) === -1 ? "" : "upvote-on";
+					tr
+						td !{cancer} 
+						td #{mutation_class(mutationClass)}
+						td #{mutation_type(mutationType)}
+						td #{proteinSeqChange}
+						td !{pubmedLink(pmid_ref)}
+						td !{d.source}
+						td 
+							a(href="#", class="downvote #{downVoteClass}", annotation-id="#{d._id}", pmid="#{pmid_ref}") &#x25BC;&nbsp;								
+							span(id="vote-#{d._id}-#{pmid_ref}") #{numVotes}
+							a(href="#", class="upvote  #{upVoteClass}", annotation-id="#{d._id}", pmid="#{pmid_ref}") &#x25B2;
+>>>>>>> wrote query for counting annotations; modified gene annotations view for flat answer
 		br
 		div(id="annotationStatus", class="text-center", style="width:100%;")
 

--- a/views/annotations/gene.jade
+++ b/views/annotations/gene.jade
@@ -82,10 +82,9 @@ block body
 						td !{pubmedLink(pmid_ref)}
 						td !{d.source}
 						td 
-							a(href="#", class="downvote #{downVoteClass}", annotation-id="#{d._id}", pmid="#{pmid_ref}") &#x25BC;&nbsp;								
-							span(id="vote-#{d._id}-#{pmid_ref}") #{numVotes}
-							a(href="#", class="upvote  #{upVoteClass}", annotation-id="#{d._id}", pmid="#{pmid_ref}") &#x25B2;
->>>>>>> wrote query for counting annotations; modified gene annotations view for flat answer
+							a(href="#", class="downvote #{downVoteClass}", annotation-id="#{d.u_id}", pmid="#{pmid_ref}") &#x25BC;&nbsp;								
+							span(id="vote-#{d.u_id}-#{pmid_ref}") #{numVotes}
+							a(href="#", class="upvote  #{upVoteClass}", annotation-id="#{d.u_id}", pmid="#{pmid_ref}") &#x25B2;
 		br
 		div(id="annotationStatus", class="text-center", style="width:100%;")
 

--- a/views/annotations/gene.jade
+++ b/views/annotations/gene.jade
@@ -66,10 +66,9 @@ block body
 				-for (var i = 0; i < annotations.length; i++)
 					- var d = annotations[i];
 					- var cancer = cancerAbbr(d.cancer)
-					- var mutationClass = d.mutation_class ? d.mutation_class : "--";
-					- var mutationType = d.mutation_type ? d.mutation_type : "--";
-					- var proteinSeqChange = d.change ? d.change : "--";
-
+					- var mutationClass = d.mut_class ? d.mut_class : "--";
+					- var mutationType = d.mut_type ? d.mut_type : "--";
+					- var proteinSeqChange = d.protein_seq_change ? d.protein_seq_change : "--";
 					- var numVotes = d.upvotes.length - d.downvotes.length;
 					- var pmid_ref = d.reference
 					- var downVoteClass = d.downvotes.indexOf(user_id) === -1 ? "" : "downvote-on";


### PR DESCRIPTION
SQL annotation additions.  Start up a postgres instance and assign the correct values to POSTGRES_HOST and POSTGRES_PORT (127.0.0.1 and 5432 should be default).

The current update 
- initializes the tables for annotations (see the schema in the google docs)
- adds mutation and ppi annotations
- permits votes for mutations
- allows mutation annotations to be seen in a gene table

At some point I'd like to prioritize watir tests for all sql annotations to make sure they stay working in production.  do you think this should be a priority? 
