### PR TITLE
integrate stats server into a Python script called by a child process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This repository contains the source code for MAGI. MAGI is written in [Node.js](
    1. Make sure that you make a directory to store the database. The default is `/data/db`,
       so you'll need to make that directory before running `mongod`.
    2. Make sure that the `mongod`, `mongo`, etc. are in your `PATH`.
-* [PyMongo](https://api.mongodb.org/python/current/installation.html) (to load data into MAGI). PyMongo can be installed through `conda` (`conda install pymongo`) or your preferred Python package manager.
+* [Python](https://www.python.org/). Tested with version 2.7.x.
+    * [PyMongo](https://api.mongodb.org/python/current/installation.html) to load data into MAGI.
+    * [Numpy](http://www.numpy.org/), [SciPy](http://scikit-learn.org/stable/), and [Scikit-Learn](http://www.scipy.org/) to compute the statistical association of mutations with different sample annotations/categories, or the (dis)similarity of different sample annotations/categories.
 
 MAGI has been tested on both Linux and Mac systems using Chrome, Firefox, and Safari.
 
@@ -65,19 +67,6 @@ MAGI has been tested on both Linux and Mac systems using Chrome, Firefox, and Sa
 
 8. View the website at `http://localhost:8000/`.
 
-
-### Statistics Engine ###
-
-The MAGI stats server is required for MAGI to provide enrichment statistics for various data.  To set up the compute engine:
-
-1. Clone the MAGI statistics server repository from: https://github.com/raphael-group/magi-stat-server.
-2. Follow the installation instructions. You will need Python 2.7 and the packages in statserver/requirements.txt in order to run the statistics server.  
-3. The statistics server can be run to listen on port 9999 with the following:
-
-        python statserver/statserver.py --port 9999
-        
-Note that MAGI's statistics server is only required for computing enrichment statistics.
-
 ### Configuration ###
 
 Users can customize MAGI and integrate it with different APIs by setting Linux environment variables. (For a quick tutorial, see [this blog post on Digital Ocean](https://www.digitalocean.com/community/tutorials/how-to-read-and-set-environmental-and-shell-variables-on-a-linux-vps).)
@@ -96,7 +85,6 @@ Users can customize MAGI and integrate it with different APIs by setting Linux e
 5. **MongoDB**. By default, MAGI assumes that MongoDB is running on the `"localhost"` server using a database named `"magi"`. You can configure to look for data on a different server or in a different database using the `MONGO_HOST` and/or `MONGO_DB_NAME` environment variables.  If you use a non-standard port for Mongo, you can set the `MONGO_PORT` environment variable accordingly. 
 6. **Feedback**. MAGI uses [WebEngage](https://webengage.com/) for collecting feedback from users. If you want to use WebEngage for your own version of MAGI, you first need to set up an account on the WebEngage website. Then, you can configure MAGI to use your account by setting the `WEBENGAGE_ID` environment variable to use your site's WebEngage ID.
 7. **Webmaster tools**. In order to use Google and Bing's webmaster tools, you need to serve a file from your web server. MAGI can be configured to do this automatically by setting the `GOOGLE_SEO_ROUTE`, `GOOGLE_SEO_ROUTE_NAME`, and/or `BING_SEO_ROUTE` environment variables. First, place the files in the MAGI directory, and then point to them using the environment variables.
-8. **Enrichment server** In order to use enrichment statistics, you should run the server above either on the local host or on a separate machine.  The `ENRICHMENT_HOST` should be set to either localhost, or the IP address/host alias of the separate machine, respectively, and the `ENRICHMENT_PORT` value should be set to the port you choose.
 
 ### Support ###
 

--- a/stats/computeEnrichments.py
+++ b/stats/computeEnrichments.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+# Load required modules
+import sys, os, json, numpy, time
+import magistats as S # local
+
+# rounds all the floats in a json
+def round_all(obj, N):
+	if isinstance(obj, float):
+		return round(obj, N)
+	elif isinstance(obj, dict):
+		return dict((k, round_all(v, N)) for (k, v) in obj.items())
+	elif isinstance(obj, (list, tuple)):
+		return map(lambda o: round_all(o, N), obj)
+	return obj
+
+def get_parser(): 
+	import argparse
+	parser = argparse.ArgumentParser(description='')
+	parser.add_argument('-r', '--request', type=str,
+		required=True, help='Request (JSON).')
+	return parser
+
+def run( args ):
+	# load raw data
+	rawdata = json.loads( args.request )
+
+	# Sometimes JSON loading once isn't enough, in which case load it again
+	# TODO: figure out why you need this, doesn't make any sense
+	if type(rawdata) == type(u""): rawdata = json.loads(rawdata)
+
+	# choose the request type
+	requestType = "contingency" # default
+	if "request" in rawdata:
+		requestType = rawdata["request"]
+
+	# check if we have that request
+	stat_packages = dict(contingency=S.contingency_tests,
+						 partitions=S.partition_tests)
+
+	if requestType not in stat_packages:
+		sys.exit(2) # Unknown request
+		return
+
+	# get the statistics package
+	engine = stat_packages[requestType]()
+	
+	# check for any known errors
+	errors = engine.validate(rawdata)
+	if errors:
+		sys.exit(3) # Errors
+		return
+		
+	# compute result
+	result = engine.tests(rawdata)		
+	result['request'] = requestType 
+	print json.dumps(result)
+
+if __name__ == "__main__": run( get_parser().parse_args(sys.argv[1:]) )

--- a/stats/magistats.py
+++ b/stats/magistats.py
@@ -1,0 +1,206 @@
+# a local statistics 
+from scipy import stats
+import numpy
+import sklearn.metrics
+
+# return contingency table, x categories, y categories
+def tabulate(x_list, y_list):
+	x_cats, xinv = numpy.unique(x_list, return_inverse=True)
+	y_cats, yinv = numpy.unique(y_list, return_inverse=True)
+
+	c_table = numpy.zeros((len(x_cats), len(y_cats)))
+	for pair in zip(xinv, yinv):
+		c_table[pair[0]][pair[1]] += 1
+		
+	pretty_table = [[""] + list(y_cats)]
+	for x, row in zip(x_cats, c_table.tolist()):
+		pretty_table.append([x] + row)
+
+	return (c_table, x_cats, y_cats, pretty_table)
+
+# statistics reporters
+class Fisher(object):
+	def __init__(self, x_cats, y_cats):
+		self.x_cats = list(x_cats)
+		self.y_cats = list(y_cats)
+
+	def calc(self, c_table): # two-sided
+		p = stats.fisher_exact(c_table)[1]
+		html = "<b>P-value</b> = %s" % format(p, 'g')
+		tex = "$P = %s$" % format(p, 'g')
+		res = dict(p=p, X=", ".join(self.x_cats), Y=", ".join(self.y_cats),
+				   report=dict(tex=tex, html=html))
+		return res
+	
+	def title(self):
+		return "Fisher's exact test, %s vs %s on %s vs %s membership" % \
+		   (self.x_cats[0], self.x_cats[1], self.y_cats[0], self.y_cats[1])
+
+class Chi2(object):
+	def __init__(self, x_cats, y_cats):
+		self.x_cats = list(x_cats)
+		self.y_cats = list(y_cats)
+
+	def calc(self, c_table):
+		res = dict(zip(["chi2", "p", "DOF", "Expected"],
+				  stats.chi2_contingency(c_table)))
+		res["Valid (all cells > 5)"] = bool((res["Expected"] >= 5).all())
+		res["Expected"] = res["Expected"].tolist()
+		res["X"] = ", ".join(self.x_cats)
+		res["Y"] = ", ".join(self.y_cats)
+		tex = "$\chi^2(%d) = %0.4f, P = %0.4f$" % (res['DOF'],res['chi2'],res['p'])
+		html = "&chi;<sup>2</sup>(%d) = %s, <b>P-value</b> = %s" % (res['DOF'],format(res['chi2'], 'g'),format(res['p'], 'g'))
+		res["report"] = dict(tex=tex, html=html)
+		return res
+
+	def title(self):
+		return "Chi square test, (%s) on (%s) membership" % \
+		   (", ".join(self.x_cats), ", ".join(self.y_cats))
+
+class AdjustedRandIndex(object):
+	def __init__(self, x_labeling, y_labeling):
+		self.x_cats = list(x_labeling)
+		self.y_cats = list(y_labeling)
+
+	def calc(self, x_cluster, y_cluster):
+		# get the adjusted rand index
+		ARI = sklearn.metrics.adjusted_rand_score(x_cluster, y_cluster)
+		report = dict(tex="$ARI = {}$".format(ARI), html="ARI = {}".format(round(ARI, 3)))
+		return {"ARI": ARI, "report": report}
+
+	def title(self):
+		return "Adjusted Rand Index, (%s) vs (%s) labeling" % \
+			   (self.x_cats, self.y_cats)
+
+
+########## validation ########### 
+def check_same_type(lis, name):
+	t = set(map(type, lis))
+	if type(None) in t: t.remove(type(None))
+	if len(t) > 1:
+		return name + " has non-homogeneous type"
+	elif not t:
+		return name + " is all None/null"
+	return None
+
+def check_exists_and_same_type(data, field_name):
+	if field_name not in data:
+		return "Missing %s variable" % field_name
+	else:
+		return check_same_type(data[field_name], field_name)
+
+######### common data operations ##############
+	# removing nulls in pairs
+def remove_paired_nulls(raw, x_field, y_field):
+	xIndicesToRemove = set( i for i, x in enumerate(raw[x_field]) if x is None or x.lower() == 'null' )
+	yIndicesToRemove = set( i for i, y in enumerate(raw[y_field]) if y is None or y.lower() == 'null' )
+	indicesToRemove = xIndicesToRemove | yIndicesToRemove
+	raw[x_field] = [ x for i, x in enumerate(raw[x_field]) if i not in indicesToRemove ]
+	raw[y_field] = [ y for i, y in enumerate(raw[y_field]) if i not in indicesToRemove ]
+	return indicesToRemove
+	
+################ set of tests for contingency-type data ##################
+class contingency_tests(object):
+# expects that rawdata contains two homogeneous vectors under entries 'X' and 'Y' of equal length
+	def validate(self, raw): 
+		errors = []
+		for f in ['X','Y']:
+			err = check_exists_and_same_type(raw, f) 
+			if err:
+				errors.append(err)
+		
+		if 'X' in raw and 'Y' in raw: # should be same length
+			if len(raw['X']) <> len(raw['Y']):
+				errors.append('X and Y are unequal lengths')
+				
+		return errors
+
+	def tests(self, rawdata):
+		# remove the nulls
+		indicesRemoved = remove_paired_nulls(rawdata,'X','Y')
+
+		# get contingency table
+		(c_table, x_cats, y_cats, pretty_table) = \
+				  tabulate(rawdata['X'], rawdata['Y'])
+
+		# construct the results object, including the contingency table
+		result = dict(table=pretty_table, \
+					  stats={}, \
+					  samplesRemoved=len(indicesRemoved))
+
+		# check the number of categories
+		nx, ny = len(x_cats), len(y_cats)
+		if nx == 1 or ny == 1: # can't run tests on a vector
+			pass
+
+		elif nx == 2 and ny == 2:
+			# run on 2x2 table
+			fisher = Fisher(x_cats, y_cats)
+			result['stats'][fisher.title()] = fisher.calc(c_table)
+
+		else:
+			# run the r x c chi-squared test
+			chi2 = Chi2(x_cats, y_cats)
+			result['stats'][chi2.title()] = chi2.calc(c_table)
+
+			# calculate marginal distributions
+			if (nx == 2 and ny > 2) or (nx > 2 and ny == 2):
+				# calculate marginal distributions
+				margin_X = numpy.sum(c_table,1)
+				margin_Y = numpy.sum(c_table,0)
+				total = numpy.sum(margin_X)
+
+				# generate all pairs of categories
+				Xs = range(nx) if nx > 2 else [0]
+				Ys = range(ny) if ny > 2 else [0]
+				for i, j in [ (x, y) for x in Xs for y in Ys ]:
+					# Create a new dataset where we simplify the category with more
+					# than two values into a binary category
+					sub_table = numpy.zeros((2,2))
+					sub_table[0,0] = c_table[i,j]
+					sub_table[0,1] = margin_X[i] - c_table[i,j]
+					sub_table[1,0] = margin_Y[j] - c_table[i,j]
+					sub_table[1,1] = total - numpy.sum(sub_table)
+					subx_cats = [x_cats[i], "Not " + x_cats[i]] if nx > 2 else x_cats
+					suby_cats = [y_cats[j], "Not " + y_cats[j]] if ny > 2 else y_cats
+
+					# Perform Fisher's exact test
+					fisher = Fisher(subx_cats, suby_cats)
+					sub_result = fisher.calc(sub_table)
+
+					result['stats'][fisher.title()] = sub_result
+
+		return result
+
+################ set of tests for contingency-type data ##################
+class partition_tests(object):
+# expects that rawdata contains two homogeneous vectors under entries 'X' and 'Y' of equal length
+	def validate(self, raw):
+		errors = []
+		for f in ['X','Y']:
+			err = check_exists_and_same_type(raw, f) 
+			if err:
+				errors.append(err)
+		
+		if 'X' in raw and 'Y' in raw: # should be same length
+			if len(raw['X']) <> len(raw['Y']):
+				errors.append('X and Y are unequal lengths')
+
+		return errors
+
+	def tests(self, raw): # return the ARI
+		indicesRemoved = remove_paired_nulls(raw, 'X','Y')
+
+		# get the contingency table
+		(_, x_cats, y_cats, pretty_table) = \
+				  tabulate(raw['X'], raw['Y'])
+
+		ari = AdjustedRandIndex(x_cats, y_cats)
+
+		# construct the results object, including the contingency table
+		result = dict(table=pretty_table,
+					  stats={}, \
+					  samplesRemoved=len(indicesRemoved))
+		result['stats'][ari.title()] = ari.calc(raw['X'], raw['Y'])
+		
+		return result

--- a/views/enrichments.jade
+++ b/views/enrichments.jade
@@ -297,6 +297,7 @@ block belowTheFold
 				if (j > i) categoryPairs.push([c1, c2]);
 			})
 		});
+
 		var promises = categoryPairs.map(function(arr){
 			var c1 = arr[0],
 				c2 = arr[1],


### PR DESCRIPTION
### Contributions
- Create new `stats/` directory with
  - `computeEnrichments.py` script that takes a single argument `-r [JSON]` and outputs a JSON of the enrichment results to stdout (all other stdout removed)
  - `magistats.py` copied from the magi-stats-server repository
- Update `routes/enrichments.js` to call the `computeEnrichments.py` script via a child process
- Update the README with the new instructions for using the stats server
### Future Work (low priority)
- Additional arguments to `computeEnrichments.py` to output in different formats
- Different design so that we don't have to use stdout to get the results of `computeEnrichments.py` back into the Node.js webserver
- Better error handling
