### PR TITLE
moving annotations from mongo to sql on view page

### DIFF
--- a/public/js/view.js
+++ b/public/js/view.js
@@ -293,8 +293,11 @@ function view(){
 						];
 
 					cancerNames.forEach(function(cancer){
+					    var refsUsed = [];
 						cancerToRefs[cancer].forEach(function(ref, i){
 							// only show the cancer name in the first row
+						    if (refsUsed.indexOf(ref.pmid) == -1) {
+							refsUsed.push(ref.pmid);
 							refTable.push([
 								{ type: 'text', text: i ? "" : cancerToName(cancer) },
 								{ type: 'link', body: ref.pmid, href: pubmedLink(ref.pmid)},
@@ -331,6 +334,7 @@ function view(){
 								  	return ref.vote;
 								  }}
 							].map(gd3.tooltip.datum));
+						    }
 						});
 					});
 

--- a/public/js/view.js
+++ b/public/js/view.js
@@ -380,8 +380,9 @@ function view(){
 				{type: 'text', text: 'Votes'}
 			].map(gd3.tooltip.datum)
 		];
-		d.categories.forEach(function(n){
-			if (d.references[n].length > 0){
+		
+	    d.categories.forEach(function(n){
+		if (d.references[n].length > 0){
 				d.references[n].forEach(function(ref, i){
 					ref.score = ref.upvotes.length - ref.downvotes.length;
 					if (ref.upvotes.indexOf(user_id) > -1){
@@ -438,7 +439,7 @@ function view(){
 						 }}
 					].map(gd3.tooltip.datum));
 				})
-			} else{
+			} else {
 				refTable.push(gd3.tooltip.datum({type: 'text', text: n}));
 			}
 		});

--- a/routes/view.js
+++ b/routes/view.js
@@ -281,9 +281,7 @@ exports.view  = function view(req, res){
 
 							    SQLannotations.ppilist(genes, function(err, ppis) {
 								SQLannotations.ppicomments(ppis, user_id, function(err, comments){
-								    console.log("comments");
 								    formatPPIs(ppis, user_id, function(err, edges, refs){
-									console.log("formatting");
 									var Cancer = Database.magi.model( 'Cancer' );
 									Cancer.find({}, function(err, cancers){
 									    if (err) throw new Error(err);
@@ -324,7 +322,6 @@ exports.view  = function view(req, res){
 										sampleAnnotations: sampleAnnotations,
 										geneToAnnotationCount: geneToAnnotationCount
 									    };
-									    console.log("rendering")
 									    // Render view
 									    res.render('view', {data: pkg, showDuplicates: req.query.showDuplicates || false, user: req.user });
 									});
@@ -374,13 +371,15 @@ function formatPPIs(ppis, user_id, callback){
 		var references = {};
 		networks.forEach(function(n){ references[n] = []; });
 		edgeNames[edgeName].forEach(function(d){
+		    if (d.refs.pmid && d.refs.pmid != '' ) {
 			references[d.name] = references[d.name].concat( d.refs );
+		    }
 		});
 
 		// Update the map of each network's edge's references to
 		// its votes and whether or not it was voted for by the current user
 		networks.forEach(function(n){
-			// Initialize the hashs for each component of this edge (if necessary)
+			// Initialize the hashes for each component of this edge (if necessary)
 			if (!(n in refs)) refs[n] = {};
 			if (!(source in refs[n])) refs[n][source] = {};
 			if (!(target in refs[n][source])) refs[n][source][target] = {};


### PR DESCRIPTION
Main view page now reads annotations from postgresql, not mongo.  

Votes are not synchronized between view page and main page.  Also issue #17 , which is UI related, is raised (should votes be assignable to incomplete descriptions of annotations).
