### PR TITLE
Edit germline and measurement type for single annotations

### DIFF
--- a/model/aberrations.js
+++ b/model/aberrations.js
@@ -76,6 +76,26 @@ exports.upsertAber = function(data, callback){
     })
 }
 
+exports.update = function(data, callback) {
+    var abers = Schemas.aberrations;
+
+    var updateQuery = abers.update(data).
+	where(abers.anno_id.equals(data.anno_id)).
+	returning(abers.anno_id);
+    Database.execute(updateQuery, function(err, result) {
+	if (err == null && result.rows.length == 0) {
+	    err = Error("Did not return annotation ID");
+	}
+	if (err) {
+            console.log("Error upserting gene annotation: " + err);
+	    console.log("Debug: full query:", query.string)
+	    callback(err, null);
+	} else {
+	    callback(null, result.rows[0]);
+	}	
+    });
+}
+
 // Loads annotations into the database
 exports.loadFromFile = function(filename, source, callback){
     // Load required modules

--- a/model/annotations_schema.js
+++ b/model/annotations_schema.js
@@ -62,7 +62,7 @@ votes = sql.define({
 	{name: 'voter_id', dataType: 'varchar(40)', notNull: true, primaryKey: true},
 	// integrity check: only one vote at a time
 	{name: 'direction', dataType: 'smallint', notNull: true},
-	{name: 'comment', dataType: 'varchar(300)'}]
+	{name: 'comment', dataType: 'varchar(3000)'}]
 })
 
 function initDatabase() {

--- a/public/js/dataTableWrapper.js
+++ b/public/js/dataTableWrapper.js
@@ -47,7 +47,7 @@ $.fn.dataTableExt.oApi.fnPagingInfo = function ( oSettings )
             0 : Math.ceil( oSettings.fnRecordsDisplay() / oSettings._iDisplayLength )
     };
 }
- 
+
 /* Bootstrap style pagination control */
 $.extend( $.fn.dataTableExt.oPagination, {
     "bootstrap": {
@@ -59,7 +59,7 @@ $.extend( $.fn.dataTableExt.oPagination, {
                     fnDraw( oSettings );
                 }
             };
- 
+
             $(nPaging).addClass(oSettings.sTableId + "_paging").append(
                 '<ul class="pagination">'+
                     '<li class="prev disabled"><a href="#">&laquo; '+oLang.sPrevious+'</a></li>'+
@@ -70,13 +70,13 @@ $.extend( $.fn.dataTableExt.oPagination, {
             $(els[0]).bind( 'click.DT', { action: "previous" }, fnClickHandler );
             $(els[1]).bind( 'click.DT', { action: "next" }, fnClickHandler );
         },
- 
+
         "fnUpdate": function ( oSettings, fnDraw ) {
             var iListLength = 5;
             var oPaging = oSettings.oInstance.fnPagingInfo();
             var an = oSettings.aanFeatures.p;
             var i, j, sClass, iStart, iEnd, iHalf=Math.floor(iListLength/2);
- 
+
             if ( oPaging.iTotalPages < iListLength) {
                 iStart = 1;
                 iEnd = oPaging.iTotalPages;
@@ -91,11 +91,11 @@ $.extend( $.fn.dataTableExt.oPagination, {
                 iStart = oPaging.iPage - iHalf + 1;
                 iEnd = iStart + iListLength - 1;
             }
- 
+
             for ( i=0, iLen=an.length ; i<iLen ; i++ ) {
                 // Remove the middle elements
                 $('li:gt(0)', an[i]).filter(':not(:last)').remove();
- 
+
                 // Add the new list items and their event handlers
                 for ( j=iStart ; j<=iEnd ; j++ ) {
                     sClass = (j==oPaging.iPage+1) ? 'class="active"' : '';
@@ -107,14 +107,14 @@ $.extend( $.fn.dataTableExt.oPagination, {
                             fnDraw( oSettings );
                         } );
                 }
- 
+
                 // Add / remove disabled classes from the static elements
                 if ( oPaging.iPage === 0 ) {
                     $('li:first', an[i]).addClass('disabled');
                 } else {
                     $('li:first', an[i]).removeClass('disabled');
                 }
- 
+
                 if ( oPaging.iPage === oPaging.iTotalPages-1 || oPaging.iTotalPages === 0 ) {
                     $('li:last', an[i]).addClass('disabled');
                 } else {

--- a/routes/annotations.js
+++ b/routes/annotations.js
@@ -123,6 +123,26 @@ exports.mutation = function mutation(req, res) {
     });
 };
 
+exports.updateMutation = function updateMutation(req, res) {
+    console.log('/annotation/updateMutation, id =', req.params.u_id)
+    var anno_id = req.params.u_id;
+    if (req.user && req.body) {
+	console.log(req.body);
+	Aberrations.update(req.body, function(err, result) {
+	    // Throw error (if necessary)
+	    if (err) {
+		res.send({ error: "Annotation could not be updated. " + err });
+		// todo: handle error: interpret or pass up if critical (no database, no table)
+		throw new Error(err);
+	    }
+	    res.send({ status: "Annotation updated successfully!", annotation: { _id: anno_id } });
+	});
+    } else {
+	res.send({ error: "You must be logged in to update annotations." });
+    }
+
+};
+
 exports.saveMutation = function saveMutation(req, res) {
     console.log('/save/annotation/mutation')
 
@@ -158,7 +178,7 @@ exports.saveMutation = function saveMutation(req, res) {
 
 	// TODO: test behavior on attempting to upsert identical annotation?
 	Aberrations.upsertAber(query, function(err, annotation){
-	    if (err){
+	    if (err) {
 		res.send({ error: "Annotation could not be parsed. " + err });
 		// todo: handle error: interpret or pass up if critical (no database, no table)
 		throw new Error(err);

--- a/routes/annotations.js
+++ b/routes/annotations.js
@@ -199,7 +199,6 @@ function removeAnnotation(req, res){
 // Save a vote on a mutation
 // FIXME: link here is not working...
 exports.mutationVote = function mutationVote(req, res){
-    console.log("/vote/mutation/" + req.body._id)
     // Only allow logged in users to vote
     if (req.isAuthenticated()){
 	if (!req.body){
@@ -207,8 +206,7 @@ exports.mutationVote = function mutationVote(req, res){
 	    return;
 	}
 
-	console.log(req.body);
-	// Add the annotation, forcing the user ID to be a string to make finding it in arrays easy
+ 	// Add the annotation, forcing the user ID to be a string to make finding it in arrays easy
 	var action = (req.body.vote == "remove") ? "removed" : "saved";
 	Aberrations.vote(req.body, req.user._id + "")
 	    .then(function(){

--- a/routes/router.js
+++ b/routes/router.js
@@ -85,6 +85,7 @@ exports.annotations = {};
 exports.annotations.saveMutation = annotations.saveMutation;
 exports.annotations.gene = annotations.gene;
 exports.annotations.mutation = annotations.mutation;
+exports.annotations.updateMutation = annotations.updateMutation;
 exports.annotations.mutationVote = annotations.mutationVote;
 exports.annotations.cancer = annotations.cancer;
 exports.annotations.save_ppi = annotations.savePPI;

--- a/server.js
+++ b/server.js
@@ -176,12 +176,11 @@ app.get('/manifests', routes.datasets.manifests);
 
 // FIXME: disabling cancer view and ppiVote / ppiComment for now
 //app.get('/annotations/cancer/:cancer', routes.annotations.cancer); 
-app.post('/vote/ppi', ensureAuthenticated, routes.annotations.ppiVote);
 //app.post('/comment/ppi', ensureAuthenticated, routes.annotations.ppiComment);
 
-// SQL annotation views
 app.get('/annotations/gene/:gene', routes.annotations.gene);
 app.get('/annotations/mutation/:u_id', routes.annotations.mutation);
+app.put('/annotations/mutation/:u_id', routes.annotations.updateMutation);
 app.get('/delete/annotations/mutation/:u_id', routes.annotations.removeMutation); // todo: should be a DELETE
 app.get('/delete/annotations/interaction/:u_id', routes.annotations.removePpi); // todo: should be a DELETE
 
@@ -189,8 +188,9 @@ app.get('/delete/annotations/interaction/:u_id', routes.annotations.removePpi); 
 
 //app.get('/annotations/cancer/:cancer', routes.annotations. cancer);
 app.post('/save/annotation/mutation/', ensureAuthenticated, routes.annotations.saveMutation); // todo: remove save prefix
-app.post('/vote/mutation', routes.annotations.mutationVote);
 app.post('/save/annotation/ppi', ensureAuthenticated, routes.annotations.save_ppi); 
+app.post('/vote/mutation', routes.annotations.mutationVote);
+app.post('/vote/ppi', ensureAuthenticated, routes.annotations.ppiVote);
 
 // more information
 app.get('/terms', routes.terms);

--- a/views/annotations/gene.jade
+++ b/views/annotations/gene.jade
@@ -113,8 +113,6 @@ block body
 
 
 block belowTheFold
-	script(src='/components/jquery/dist/jquery.min.js').
-	script(src='/components/bootstrap/dist/js/bootstrap.min.js').
 	script(src='/components/DataTables/media/js/jquery.dataTables.min.js').
 	script(src='/js/dataTableWrapper.js').
 	script(type='text/javascript').
@@ -124,12 +122,15 @@ block belowTheFold
 			});
                         
 		//- Set up the popovers
-		$("[data-toggle=popover]").popover({html:true, container: 'body'})
+		function setupPopovers(){
+			$("[data-toggle=popover]").popover({
+				html:true, container: 'body'
+			}).click(function(e){ e.preventDefault(); $(this).focus(); })
+		}
+		setupPopovers();
+		
 		//- Make sure the popovers are active whenever the table is updated
-		var table = $("#gene-annotation-table").DataTable();
-		table.on( 'draw', function () {
-			$("[data-toggle=popover]").popover({html:true, container: 'body'})
-		} );
+		tbl.on( 'draw', setupPopovers);
 		
 		$("#gene-annotation-table_info").css({'font-weight': 'bold', 'font-size': '110%'});
 		$(document).ready(function(){
@@ -180,6 +181,7 @@ block belowTheFold
 		tbl.on( 'draw', function () {
 			upvote();
 			downvote();
+			setupPopovers();
 		} );
 
 		function downvote(){

--- a/views/annotations/gene.jade
+++ b/views/annotations/gene.jade
@@ -194,14 +194,13 @@ block belowTheFold
 					numVotes = +(voteCount.text()),
 					comment = $('textarea#mutation-comment').val(),
 					voteDirection = 'down';
-
+				if ( el.hasClass('downvote-on')) voteDirection = 'remove'; 
 				voteMutation(annotation_id, pmid, voteDirection, comment, function() {
 					if (sibling.hasClass('upvote-on')){
 						sibling.removeClass('upvote-on');
 						el.addClass('downvote-on');
 						voteCount.text(numVotes - 2);
 					} else if (el.hasClass('downvote-on')){
-						voteDirection = 'remove';
 						el.removeClass('downvote-on');
 						voteCount.text(numVotes + 1);
 					} else {
@@ -221,13 +220,13 @@ block belowTheFold
 					numVotes = +(voteCount.text()),
 					comment = $('textarea#mutation-comment').val(),
 					voteDirection = 'up';
+				if ( el.hasClass('upvote-on')) voteDirection = 'remove'; 
 				voteMutation(annotation_id, pmid, voteDirection, comment, function () {
 					if (sibling.hasClass('downvote-on')){
 						sibling.removeClass('downvote-on');
 						el.addClass('upvote-on'); 
 						voteCount.text(numVotes + 2);
 					} else if (el.hasClass('upvote-on')){
-						voteDirection = 'remove';
 						el.removeClass('upvote-on');
 						voteCount.text(numVotes - 1);
 					} else {

--- a/views/annotations/gene.jade
+++ b/views/annotations/gene.jade
@@ -64,6 +64,7 @@ block body
 					th PMID / PMCID
 					th Source
 					th Votes
+					th Detail
 			tbody
 				-for (var i = 0; i < annotations.length; i++)
 					- var d = annotations[i];
@@ -91,8 +92,7 @@ block body
 						td !{cancer}
 						td #{mutation_class(mutationClass)}
 						td #{mutation_type(mutationType)}
-						td 
-							a(href='/annotations/mutation/#{id}') #{proteinSeqChange}
+						td #{proteinSeqChange}
 						td #{germline}
 						td #{measure_type}						  
 						td !{pubmedLink(pmid_ref)}
@@ -103,11 +103,13 @@ block body
 							a(href="#", class="downvote #{downVoteClass}", annotation-id="#{d.u_id}", pmid="#{pmid_ref}") &#x25BC;&nbsp;								
 							span(id="vote-#{d.u_id}-#{pmid_ref}") #{numVotes}
 							a(href="#", class="upvote  #{upVoteClass}", annotation-id="#{d.u_id}", pmid="#{pmid_ref}") &#x25B2;
+						td 
+							a(href='/annotations/mutation/#{id}' class="glyphicon glyphicon-pencil")
 		br
 		div(id="annotationStatus", class="text-center", style="width:100%;display:off")
-		div(id="commentVote", class="container", style="width%100;")
-			label(class="toggle")
-			| <b>Add a comment to your vote? (Optional)</b>
+		div(id="commentVote", class="container", style="width%100;")                
+			label(class="toggle")                        
+			| <b>Add a comment to your vote? (Optional)</b>                        
 			span(class="glyphicon glyphicon-remove", style="cursor:pointer;float:right", onclick="$(this).parent().hide();$('textarea#mutation-comment').hide()")
 			textarea(class="form-control", id="mutation-comment", placeholder="Enter any comments.", type="textarea")
 

--- a/views/annotations/mutation.jade
+++ b/views/annotations/mutation.jade
@@ -51,7 +51,9 @@ block body
 		-if (error)
 			h3 Annotation not found: ##{annotation_id}
 		-else
-			h3 #{annotation.gene} mutation annotation ##{annotation.u_id}
+			h3 
+				a(href="/annotations/gene/#{annotation.gene}") #{annotation.gene}
+				|  mutation annotation ##{annotation.u_id}
 			br
 			div(class="col-lg-4 col-md-4")
 				h4 Annotation Data
@@ -75,7 +77,7 @@ block body
 							+tr_prop("Source", annotation.source)
 			div(id = "right")
 				div(class="col-lg-8 col-md-8")
-					h4 Comments
+					h4 Votes
 					-if (!annotation.comments || annotation.comments.length == 0)
 						| No comments are recorded for this annotation.
 					-else
@@ -91,15 +93,20 @@ block body
 										tr(class="comment-row")
 											td(class="comment-name") #{comment.name}
 											td(class="comment-body") #{comment.comment}
-											td(class="comment-dir") #{comment.direction}
+											td(class="comment-dir") 
+												-if (comment.direction === "up")
+													span(class="glyphicon glyphicon-thumbs-up", style="color:green")
+												-else
+													span(class="glyphicon glyphicon-thumbs-down", style="color:red")
 				hr(style="clear:both")
 				div(id="commentVote", class="container", style="width%100;")
-					h4 Vote (submitting without a vote deletes comment):
+					h4 Vote and comment:
 					textarea(class="form-control", id="mutation-comment", placeholder="Enter any comments.", type="textarea")
 					| Vote: 
 					a(href="#", class="upvote" style="color:#000") &#x25B2;&nbsp;
 					a(href="#", class="downvote" style="color:#000") &#x25BC;
 					button(type="submit", id="submit", class="btn btn-default") Submit
+					p Note: comments are optional, and submitting without a vote deletes any existing vote and comment.
 				div(id="annotationStatus", class="text-center", style="width:100%;display:off")
 
 block belowTheFold
@@ -177,7 +184,7 @@ block belowTheFold
 						if(response.error) {
 							annotationStatus(response.error, warningClasses);
 						} else {
-							annotationStatus(response.status + ': reload to see updates.', successClasses);
+							annotationStatus(response.status + ': <a href="./' + uid + '">reload</a> to see updates.', successClasses);
 						}
 						clearVoteAndComment();
 					}

--- a/views/annotations/mutation.jade
+++ b/views/annotations/mutation.jade
@@ -129,7 +129,7 @@ block belowTheFold
 				if (voteDir === 'up') {
 					$('a.upvote').addClass('upvote-on');
 				} else if (voteDir === 'down') {
-					$('a.upvote').addClass('upvote-on');
+					$('a.upvote').addClass('downvote-on');
 				}
 			}
 			

--- a/views/annotations/mutation.jade
+++ b/views/annotations/mutation.jade
@@ -48,7 +48,7 @@ block body
 	-	}
 	br
 	div(class="container")
-		-if (error != "" || (annotation === undefined))
+		-if (error)
 			h3 Annotation not found: ##{annotation_id}
 		-else
 			h3 #{annotation.gene} mutation annotation ##{annotation.u_id}

--- a/views/annotations/mutation.jade
+++ b/views/annotations/mutation.jade
@@ -56,25 +56,52 @@ block body
 				|  mutation annotation ##{annotation.u_id}
 			br
 			div(class="col-lg-4 col-md-4")
+				-var is_germline = annotation.is_germline ? annotation.is_germline : "--";
+				-var measurement_type = annotation.measurement_type ? annotation.measurement_type : "--";
 				h4 Annotation Data
 					mixin tr_prop(property, value)
 						tr 
 							td #{property}
-							td !{value}
+							td 
+								block
 					table(class="table table-striped", id="annotation-table", annotation-id="#{annotation.u_id}")
 						thead
 							tr(style="background:#d3d3d3")
 								th Property
 								th Value
 						tbody
-							+tr_prop("Cancer", cancerAbbr(annotation.cancer))
-							+tr_prop("Mutation class", mutation_class(annotation.mut_class))
-							+tr_prop("Mutation type", mutation_type(annotation.mut_type))
-							+tr_prop("Protein sequence change", annotation.protein_seq_change)
-							+tr_prop("Germline?", annotation.is_germline ? annotation.is_germline : "--")
-							+tr_prop("Measurement type", annotation.measurement_type ? annotation.measurement_type : "--")
-							+tr_prop("PMID", pubmedLink(annotation.reference))
-							+tr_prop("Source", annotation.source)
+							+tr_prop("Cancer") !{cancerAbbr(annotation.cancer)}
+							+tr_prop("Mutation class") !{mutation_class(annotation.mut_class)}
+							+tr_prop("Mutation type") !{mutation_type(annotation.mut_type)}
+							+tr_prop("Protein sequence change") !{annotation.protein_seq_change}
+							+tr_prop("Germline?")
+								div(id='view-germline-div')
+									!{is_germline}
+									span(id="edit-germline", 
+										class="glyphicon glyphicon-pencil",
+										style="float:right;cursor:pointer",
+										onclick="$(this).parent().next().show();$(this).parent().hide();")
+								div(id='edit-germline-div', style='display:none')
+									select(id="germline", class="form-control")
+										option(value=null) --
+										option(value=false) False
+										option(value=true) True
+									span(id="confirm_germline", class="glyphicon glyphicon-ok-circle" style="float:right;cursor:pointer")
+							+tr_prop("Measurement type")
+								div(id='view-measurement-div')
+									!{measurement_type}
+									span(id="edit-measurement", 
+										class="glyphicon glyphicon-pencil",
+										style="float:right;cursor:pointer",
+										onclick="$(this).parent().next().show();$(this).parent().hide();")
+								div(id='edit-measurement-div', style='display:none')
+									input(class="form-control", 
+										type="text", 
+										id="measurent_type", 
+										placeholder=measurement_type)
+									span(id="confirm_measurement_type", class="glyphicon glyphicon-ok-circle" style="float:right;cursor:pointer")
+							+tr_prop("PMID") !{pubmedLink(annotation.reference)}
+							+tr_prop("Source") !{annotation.source}
 			div(id = "right")
 				div(class="col-lg-8 col-md-8")
 					h4 Votes
@@ -124,8 +151,7 @@ block belowTheFold
 			warningClasses = 'alert alert-warning',
 			successClasses = 'alert alert-success';
 
-		$(document).ready(function() {
-		
+		$(document).ready(function() {		
 			var my_comment = $('.comment-name').filter(function () { 
 				return $.text([this]) != 'Anonymous';
 			});
@@ -154,7 +180,7 @@ block belowTheFold
 					sibling.removeClass('upvote-on');
 				}
 			});
-
+                        
 			$('button#submit').on('click', function() {
 				var vote = 'remove';
 				if ($('a.upvote').hasClass('upvote-on')) {
@@ -196,4 +222,10 @@ block belowTheFold
 				$('a.upvote').removeClass('upvote-on');
 				$('a.downvote').removeClass('downvote-on');
 			}
+                        
+			$('span.glyphicon-ok-circle').on('click', function() {
+				var formData = new FormData();
+				$(this).parent().prev().show();
+				$(this).parent().hide();
+			});
 		});

--- a/views/annotations/mutation.jade
+++ b/views/annotations/mutation.jade
@@ -2,8 +2,8 @@ extends ../layout
 block body
 	//- Helper javascript functions
 	- var pubmedLink = function (_id){
-	- 		if (_id.toLowerCase().slice(0, 3) == 'pmc'){
-	- 			var href = 'http://www.ncbi.nlm.nih.gov/pmc/articles/' + _id;
+	-		if (_id.toLowerCase().slice(0, 3) == 'pmc'){
+	-			var href = 'http://www.ncbi.nlm.nih.gov/pmc/articles/' + _id;
 	-		} else{
 	-			var href = 'http://www.ncbi.nlm.nih.gov/pubmed/' + _id;
 	-		}
@@ -56,7 +56,6 @@ block body
 				|  mutation annotation ##{annotation.u_id}
 			br
 			div(class="col-lg-4 col-md-4")
-				-var is_germline = annotation.is_germline ? annotation.is_germline : "--";
 				-var measurement_type = annotation.measurement_type ? annotation.measurement_type : "--";
 				h4 Annotation Data
 					mixin tr_prop(property, value)
@@ -76,20 +75,21 @@ block body
 							+tr_prop("Protein sequence change") !{annotation.protein_seq_change}
 							+tr_prop("Germline?")
 								div(id='view-germline-div')
-									!{is_germline}
+									div(id='view-germline-label' style='float:left' class='entry')
+										!{annotation.is_germline}
 									span(id="edit-germline", 
 										class="glyphicon glyphicon-pencil",
 										style="float:right;cursor:pointer",
 										onclick="$(this).parent().next().show();$(this).parent().hide();")
 								div(id='edit-germline-div', style='display:none')
-									select(id="germline", class="form-control")
-										option(value=null) --
-										option(value=false) False
-										option(value=true) True
+									select(id="is_germline_field", class="form-control", selected="#{annotation.is_germline}")
+										option false
+										option true
 									span(id="confirm_germline", class="glyphicon glyphicon-ok-circle" style="float:right;cursor:pointer")
 							+tr_prop("Measurement type")
 								div(id='view-measurement-div')
-									!{measurement_type}
+									div(id='view-measurement-label' style='float:left' class='entry')
+										!{measurement_type}
 									span(id="edit-measurement", 
 										class="glyphicon glyphicon-pencil",
 										style="float:right;cursor:pointer",
@@ -97,7 +97,7 @@ block body
 								div(id='edit-measurement-div', style='display:none')
 									input(class="form-control", 
 										type="text", 
-										id="measurent_type", 
+										id="measurement_type_field",
 										placeholder=measurement_type)
 									span(id="confirm_measurement_type", class="glyphicon glyphicon-ok-circle" style="float:right;cursor:pointer")
 							+tr_prop("PMID") !{pubmedLink(annotation.reference)}
@@ -152,6 +152,7 @@ block belowTheFold
 			successClasses = 'alert alert-success';
 
 		$(document).ready(function() {		
+			var uid = $('#annotation-table').attr('annotation-id');
 			var my_comment = $('.comment-name').filter(function () { 
 				return $.text([this]) != 'Anonymous';
 			});
@@ -180,7 +181,7 @@ block belowTheFold
 					sibling.removeClass('upvote-on');
 				}
 			});
-                        
+			
 			$('button#submit').on('click', function() {
 				var vote = 'remove';
 				if ($('a.upvote').hasClass('upvote-on')) {
@@ -190,7 +191,6 @@ block belowTheFold
 				}
 
 				var formData = new FormData();
-				var uid = $('#annotation-table').attr('annotation-id');
 				var comment_body = $('textarea#mutation-comment').val() ? $('textarea#mutation-comment').val() : "<empty>";
 
 				formData.append( "_id", uid );
@@ -210,10 +210,12 @@ block belowTheFold
 						if(response.error) {
 							annotationStatus(response.error, warningClasses);
 						} else {
-							annotationStatus(response.status + ': <a href="./' + uid + '">reload</a> to see updates.', successClasses);
+
+						annotationStatus(response.status + ': <a href="./' + uid + '">Reload</a> to see updates.', successClasses);
 						}
 						clearVoteAndComment();
 					}
+                                        
 				});
 			});
 			
@@ -222,10 +224,59 @@ block belowTheFold
 				$('a.upvote').removeClass('upvote-on');
 				$('a.downvote').removeClass('downvote-on');
 			}
-                        
+			
 			$('span.glyphicon-ok-circle').on('click', function() {
+				var dataField = $(this).prev();
+				var dataName = dataField.attr('id').replace('_field','');
+
+				var dataValue = dataField.val();				
+				if (dataName === 'is_germline') {
+					if (dataValue === '--') {
+						dataValue = undefined;
+					} else {
+						dataValue = (dataValue.toLowerCase() === 'true');
+					}
+				}
+
 				var formData = new FormData();
-				$(this).parent().prev().show();
-				$(this).parent().hide();
+				formData.append('anno_id', uid);
+				formData.append(dataName, dataValue);
+
+				var thisControl = $(this);
+				restoreViewMode($(this));
+				$.ajax({
+					url: './' + uid,
+					data: formData,
+					cache: false,
+					contentType: false,
+					processData: false,
+					type: 'PUT',
+					error: function(error) {
+						annotationStatus('Database error: ' + error.status, warningClasses);
+					}, 
+					success: function(response) {
+						if(response.error) {
+							annotationStatus(response.error, warningClasses);
+						} else {
+							annotationStatus(response.status, successClasses);
+							updateValue(thisControl, dataValue);
+						}
+					}					 
+				});
 			});
+			
+			function updateValue(element, newval) {
+				console.log('update', newval);
+				console.log('elem', element);
+				console.log('elem', element.parent());
+				console.log('elem', element.parent().prev());
+				console.log('elem', element.parent().prev().children('div.entry'));
+				console.log('text', element.parent().prev().children('div.entry').text());
+				element.parent().prev().children('div.entry').text(newval);
+			}
+			
+			function restoreViewMode(element) {
+				element.parent().prev().show();
+				element.parent().hide();
+			}
 		});

--- a/views/datasets/index.jade
+++ b/views/datasets/index.jade
@@ -1,7 +1,7 @@
 extends ../layout
 block body
   div(class="container")
-    h1
+    h1(style='margin-top:20px')
       | Datasets&nbsp;
       small Click a dataset's name to view a summary of its mutations.
     -var seenPublic = false;

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -2,7 +2,7 @@ doctype html
 html
   head
     meta(charset='utf8')
-    link(rel="icon", type="image/png", href="img/favicon.png")
+    link(rel="icon", type="image/png", href="/img/favicon.png")
     title MAGI
     link(rel='stylesheet', href='/components/bootstrap/dist/css/bootstrap.min.css')
     link(rel='stylesheet', href='/css/app.css')

--- a/views/sampleView.jade
+++ b/views/sampleView.jade
@@ -76,9 +76,13 @@ block belowTheFold
 		//- Convert the tables into DataTables
 		addDataTable({ tableID: "#variant-table", aaSorting: [[0, "asc"]] });
 		//- Set up the popovers
-		$("[data-toggle=popover]").popover({html:true, container: 'body'})
+		function setupPopovers(){
+			$("[data-toggle=popover]").popover({
+				html:true, container: 'body'
+			}).click(function(e){ e.preventDefault(); $(this).focus(); })
+		}
+		setupPopovers();
+
 		//- Make sure the popovers are active whenever the table is updated
 		var table = $("#variant-table").DataTable();
-		table.on( 'draw', function () {
-			$("[data-toggle=popover]").popover({html:true, container: 'body'})
-		} );
+		table.on( 'draw', setupPopovers);


### PR DESCRIPTION
Single annotation pages now have editable germline and measurement fields.  Clicking on a pencil-edit icon begins the edit and clicking the ok check confirms the edit for each field individually.
