### PR TITLE
Gene view redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This repository contains the source code for MAGI. MAGI is written in [Node.js](
 * [Postgres](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
 MAGI has been tested on both Linux and Mac systems using Chrome, Firefox, and Safari.
 
+* [librsvg](https://wiki.gnome.org/action/show/Projects/LibRsvg?action=show&redirect=LibRsvg). MAGI requires librsvg for converting figures to PNG/PDF format. You can install librsvg on Mac OS X with [Homebrew](http://brew.sh/):
+
+        brew install librsvg
+
 ### Setup ###
 
 1. Clone the repository:

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "tether-shepherd": "latest",
     "tether": "latest",
     "jquery-mousewheel": "~3.1.12",
+    "jquery-ui": "latest",
     "d3-tip": "latest",
     "jssha": "~1.6.0",
     "fontawesome": "latest"

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "tether": "latest",
     "jquery-mousewheel": "~3.1.12",
     "d3-tip": "latest",
-    "jssha": "~1.6.0"
+    "jssha": "~1.6.0",
+    "fontawesome": "latest"
   }
 }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -405,25 +405,15 @@ table.uploadDataTable * * * {
 
 /* Styling for visualizations */
 div#loading{background:#fff;width:100%;height:100%;position:fixed;left:0px;top:51px;z-index:1001;opacity:0.8;padding-left:45%;padding-top:18%}
-div#view-page{ opacity:0;min-height:800px; }
-div#control-panel{width:200px;border:#333 solid 10px;position:absolute;right:0px;background:#333;max-height:100%;overflow-y:scroll;}
-.fixed {position: fixed; top: 0; z-index: 1;right:0px;}
-
-div#control-panel h4{text-align:center;background:#333;color:#fff;padding-bottom:3px;}
-
-div#control-panel div#controls{ padding-top:2px; border-radius:4px;}
-div#control-panel div#controls ul#datasets{list-style-type: none;padding-left:4px;font-size:90%;}
-
-div#control-panel div#controls ul#datasets li div{display:inline-block;}
-div#control-panel div#controls ul#datasets li div.dataset-color{margin-right:10px;height:11px;width:11px;border-radius:3px;padding:2px;border:1px solid #eee;}
-div#view{margin-left:20px;margin-right:230px;}
-div#view h3 small{ font-size:12px;cursor:pointer;}
-div#instructions{margin-left:20px;margin-right:230px;;}
+div#controls table#datasets thead tr{background:rgb(51,51,51);color:#ffffff;}
+div#controls table#datasets tbody tr{cursor:pointer}
+div#controls table#datasets div.dataset-color{text-align:center;height:20px;width:20px;border-radius:3px;padding:2px;border:1px solid #eee;}
+div#controls tr.variant-annotations-row{cursor:pointer;}
 div#spinner{height: 300px; margin-right:230px; background-image:url('../img/spinner.gif'); background-repeat: no-repeat; background-position: center; display:none;}
 
-div.half-page-view{ width:50%;padding:5px; }
-div.half-page-view.leftside{border-right:1px solid #eee;float:left;}
-div.half-page-view.rightside{float:right;}
+div#view-page ul.list-inline{margin:0px;}
+div#view-page ul.list-inline a{ color:#999999;cursor:pointer;}
+div#view-page ul.list-inline a:hover{ text-decoration:none; color:#000000;}
 
 /* Dataset summary page */
 div#dataset-summary div#left{ width:35%;display:table-cell;}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -405,11 +405,18 @@ table.uploadDataTable * * * {
 
 /* Styling for visualizations */
 div#loading{background:#fff;width:100%;height:100%;position:fixed;left:0px;top:51px;z-index:1001;opacity:0.8;padding-left:45%;padding-top:18%}
+div#spinner{height: 300px; margin-right:230px; background-image:url('../img/spinner.gif'); background-repeat: no-repeat; background-position: center; display:none;}
+
 div#controls table#datasets thead tr{background:rgb(51,51,51);color:#ffffff;}
 div#controls table#datasets tbody tr{cursor:pointer}
 div#controls table#datasets div.dataset-color{text-align:center;height:20px;width:20px;border-radius:3px;padding:2px;border:1px solid #eee;}
 div#controls tr.variant-annotations-row{cursor:pointer;}
-div#spinner{height: 300px; margin-right:230px; background-image:url('../img/spinner.gif'); background-repeat: no-repeat; background-position: center; display:none;}
+
+@media (max-width: 768px) {
+    .affix {
+        position: relative;
+    }
+}
 
 div#view-page ul.list-inline{margin:0px;}
 div#view-page ul.list-inline a{ color:#999999;cursor:pointer;}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -424,6 +424,9 @@ div#view-page ul.list-inline{margin:0px;}
 div#view-page ul.list-inline a{ color:#999999;cursor:pointer;}
 div#view-page ul.list-inline a:hover{ text-decoration:none; color:#000000;}
 
+div#view-page ul#sort-options li div{display:block;padding:3px 20px 3px 20px;color:#999999;}
+div#view-page ul#sort-options li a span.sort-name{margin-left:5px;margin-right:5px;}
+
 /* Dataset summary page */
 div#dataset-summary div#left{ width:35%;display:table-cell;}
 div#dataset-summary table{ margin-bottom:5px;}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -411,6 +411,8 @@ div#controls table#datasets thead tr{background:rgb(51,51,51);color:#ffffff;}
 div#controls table#datasets tbody tr{cursor:pointer}
 div#controls table#datasets div.dataset-color{text-align:center;height:20px;width:20px;border-radius:3px;padding:2px;border:1px solid #eee;}
 div#controls tr.variant-annotations-row{cursor:pointer;}
+div#controls tr.variant-annotations-row .fa-external-link{display:none}
+div#controls tr.variant-annotations-row:hover .fa-external-link{display:inline}
 
 @media (max-width: 768px) {
     .affix {

--- a/public/js/save.js
+++ b/public/js/save.js
@@ -1,300 +1,61 @@
-////////////////////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// CONVENIENCE FUNCTIONS FOR IMAGE DOWNLOAD
-//
-
-var SAVEJS_CONST = {
-  CNA_VIZ: 0,
-  HMP_VIZ: 1,
-  ABERRS: 2,
-  SUB_NET: 3,
-  TRN_ANT: 4,
-};
-
-var SAVEJS_FNAMES = {
-  CNA_VIZ: 'cna.svg',
-  HMP_VIZ: 'heatmap.svg',
-  ABERRS: 'aberrations.svg',
-  SUB_NET: 'network.svg',
-  TRN_ANT: 'transcript.svg'
-}
-
-// error message box
-var checkMessage = d3.select('div#saveErrMsgContainer')
-      .append('p')
-          .style('background', 'rgb(242, 222, 222)')
-          .style('border', '1px solid rgb(205, 174, 179)')
-          .style('border-radius', '4px')
-          .style('display', 'none')
-          .style('padding', '5px')
-          .text('Error: No visualizations selected.');
-
-
-// Download any selected visualizations using a given save function. Creates error prompt if no
-//    visualizations are selected in the tool.
-//
-// saveFn (function variable) - function that takes a visualization ID and save file name as input
-function downloadVisualizations(saveFn) {
-  var saveCheckboxes = d3.selectAll('ul#saveOptList li label input')[0];
-
-  var vizSelected = saveCheckboxes[SAVEJS_CONST.CNA_VIZ].checked == true
-      || saveCheckboxes[SAVEJS_CONST.TRN_ANT].checked == true
-      || saveCheckboxes[SAVEJS_CONST.SUB_NET].checked == true
-      || saveCheckboxes[SAVEJS_CONST.ABERRS].checked == true
-      || saveCheckboxes[SAVEJS_CONST.HMP_VIZ].checked == true;
-
-  if (vizSelected == false) {
-    checkMessage.style('display', 'block');
-    return;
-  } else {
-    checkMessage.style('display', 'none');
+// Logic for printing and saving figures
+$(document).ready(function(){
+  // Function to grab an SVG
+  function grabSVG(selector){
+    var svg = null;
+    svg = d3.select('div#' + selector + ' svg');
+    svg.attr('xmlns', 'http://www.w3.org/2000/svg');
+    return svg.node();
   }
 
-  if (saveCheckboxes[SAVEJS_CONST.CNA_VIZ].checked == true) {
-    saveFn('cnas', SAVEJS_FNAMES.CNA_VIZ);
-  }
-  if (saveCheckboxes[SAVEJS_CONST.TRN_ANT].checked == true) {
-    saveFn('transcript', SAVEJS_FNAMES.TRN_ANT);
-  }
-  if (saveCheckboxes[SAVEJS_CONST.SUB_NET].checked == true) {
-    saveFn('network', SAVEJS_FNAMES.SUB_NET);
-  }
-  if (saveCheckboxes[SAVEJS_CONST.ABERRS].checked == true) {
-    saveFn('aberrations', SAVEJS_FNAMES.ABERRS);
-  }
-  if (saveCheckboxes[SAVEJS_CONST.HMP_VIZ].checked == true) {
-    saveFn('heatmap', SAVEJS_FNAMES.HMP_VIZ);
-  }
-}
+  // SAVE
+  // Set up the save links
+  var saveFigureForm = $('form#save-figure'),
+      formatInput = $('form#save-figure input#format'),
+      svgInput = $('form#save-figure input#svg');
 
+  $('.save-figure-link').click(function(){
+    // Extract this link's information
+    var el = $(this),
+        format = el.data('format'),
+        selector = el.data('selector');
+    // Extract the SVG
+    // Submit POST request
+    svgInput.val(grabSVG(selector).outerHTML);
+    formatInput.val(format);
+    saveFigureForm.submit();
+  });
 
-// Grab an SVG based on the save file name from the tool. RETURNs the d3 svg object
-//
-// saveFileName (string) - one of SAVEJS_FNAMES
-function grabSVG(saveFileName) {
-  var svg = null;
-  if (saveFileName == SAVEJS_FNAMES.SUB_NET) {
-    svg = d3.select('div#network svg');
-  } else if (saveFileName == SAVEJS_FNAMES.ABERRS) {
-    svg = d3.select('div#aberrations svg'); // TOOD: ensure mutation matrix and not legend is selected
-  } else if (saveFileName == SAVEJS_FNAMES.TRN_ANT) {
-    svg = d3.select('div#transcript svg');
-  } else if (saveFileName == SAVEJS_FNAMES.CNA_VIZ) {
-    svg = d3.select('div#cnas svg');
-  } else if (saveFileName == SAVEJS_FNAMES.HMP_VIZ) {
-    svg = d3.select('div#heatmap svg')
-  } else {
-    console.log('error: unexpected save filename in grabSVG()');
-    return;
+  // PRINT
+  // adapted from https://svgopen.org/2010/papers/62-From_SVG_to_Canvas_and_Back/index.html#svg_to_canvas
+  function importSVG(sourceSVG, targetCanvas) {
+    var svg_xml = (new XMLSerializer()).serializeToString(sourceSVG);
+    var ctx = targetCanvas.getContext('2d');
+
+    // this is just a JavaScript (HTML) image
+    var img = new Image();
+    // https://developer.mozilla.org/en/DOM/window.btoa
+    img.src = "data:image/svg+xml;base64," + btoa(svg_xml);
+
+    img.onload = function() {
+        // after this, Canvas’ origin-clean is DIRTY
+        ctx.drawImage(img, 0, 0);
+    }
+    return img;
   }
 
-  svg.attr('xmlns', 'http://www.w3.org/2000/svg');
+  $('.print-figure-link').click(function(){
+    // Extract this link's information
+    var el = $(this),
+        selector = el.data('selector');
 
-  return svg;
-}
+    // Append
+    var canvas = document.createElement('canvas'),
+      img = importSVG(grabSVG(selector), canvas),
+      w = window.open();
 
+    w.document.body.appendChild(img);
+    w.print(); //initiate print dialogue
 
-// adapted from https://svgopen.org/2010/papers/62-From_SVG_to_Canvas_and_Back/index.html#svg_to_canvas
-function importSVG(sourceSVG, targetCanvas) {
-  var svg_xml = (new XMLSerializer()).serializeToString(sourceSVG);
-  var ctx = targetCanvas.getContext('2d');
-
-  // this is just a JavaScript (HTML) image
-  var img = new Image();
-  // https://developer.mozilla.org/en/DOM/window.btoa
-  img.src = "data:image/svg+xml;base64," + btoa(svg_xml);
-
-  img.onload = function() {
-      // after this, Canvas’ origin-clean is DIRTY
-      ctx.drawImage(img, 0, 0);
-  }
-  return img;
-}
-
-
-// (De)select all event triggers
-$('#saveSelectAll').click(function(e) {
-  e.preventDefault();
-  d3.selectAll('ul#saveOptList li label input').property('checked', true);
-});
-$('#saveSelectNone').click(function(e) {
-  e.preventDefault();
-  d3.selectAll('ul#saveOptList li label input').property('checked', false);
-});
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// SVG DOWNLOAD CODE
-//
-
-// Opens up a new window so the user can then cmd+s save the SVG
-var saveSVG = function(divContainerId, saveFileName) {
-  var svg = grabSVG(saveFileName).node(),
-    canvas = document.createElement('canvas'),
-    img = importSVG(svg, canvas),
-    w = window.open();
-  w.document.body.appendChild(img);
-
-  return w;
-}
-
-// Sends the SVG to the server and then back to initiate a download prompt
-var dlSVG = function(divContainerId, saveFileName) {
-  var svg = grabSVG(saveFileName).node();
-  $.post('/saveSVG', {'html': svg.outerHTML, 'fileName': saveFileName})
-     .done(function(svgStr) {
-       // When the post has returned, create a link in the browser to download the SVG
-       // Store the data and create a download link
-       var url = window.URL.createObjectURL(new Blob([svgStr], { "type" : "text\/xml" }));
-       var a = d3.select("body")
-           .append('a')
-           .attr("download", saveFileName)
-           .attr("href", url)
-           .style("display", "none");
-
-       // Activate the download through a click event
-       a.node().click();
-
-       // Garbage collection
-       setTimeout(function() {
-         window.URL.revokeObjectURL(url);
-       }, 10);
-     });
-}
-
-// When the "Download SVG" link is clicked, download the visualizations
-$('#downloadLink').click(function() {
-  //downloadVisualizations(saveSVG);
-  downloadVisualizations(dlSVG);
-});
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// PNG DOWNLOAD CODE
-//
-
-function svgToPng(svg) {
-  var canvas = document.createElement('canvas');
-
-  // The following is adapted from http://phrogz.net/SVG/svg_to_png.xhtml
-  // It is very similar to what happens in importSVG, but takes that generated image and
-  //    prepares it for a PNG format
-  function svgDataURL(svg) {
-    var svgAsXML = (new XMLSerializer).serializeToString(svg);
-    return "data:image/svg+xml," + encodeURIComponent(svgAsXML);
-  }
-
-  var pngImg  = new Image();
-
-  var svgImg = new Image;
-
-  canvas.setAttribute('width', svg.getAttribute('width'));
-  canvas.setAttribute('height', svg.getAttribute('height'));
-  pngImg.setAttribute('width', svg.getAttribute('width'));
-  pngImg.setAttribute('height', svg.getAttribute('height'));
-
-  svgImg.setAttribute('width', svg.getAttribute('width'));
-  svgImg.setAttribute('height', svg.getAttribute('height'));
-
-  var ctx = canvas.getContext('2d');
-  svgImg.onload = function(){
-    ctx.drawImage(svgImg,0,0,pngImg.width,pngImg.height);
-    pngImg.src = canvas.toDataURL();
-  };
-  svgImg.src = svgDataURL(svg);
-
-  return pngImg;
-}
-
-// Generalized post code to handle PNG download for each visualization
-var savePNG = function(divContainerId, saveFileName) {
-  var svg = grabSVG(saveFileName).node();
-
-  var w = window.open(),
-      png = svgToPng(svg);
-  w.document.body.appendChild(png);
-
-  return w;
-}
-
-// Sends the SVG to the server and then back to initiate a download prompt
-var dlPNG = function(divContainerId, saveFileName) {
-  var svg = grabSVG(saveFileName).node(),
-      png = svgToPng(svg);
-
-  png = btoa(png);
-
-  $.post('/saveSVG', {'img': png, 'fileName': saveFileName})
-     .done(function(png) {
-      // When the post has returned, create a link in the browser to download the SVG
-      // Store the data and create a download link
-      var url = window.URL.createObjectURL(new Blob([png], { "type" : "image\/png" }));
-      var a = d3.select("body")
-          .append('a')
-          .attr("download", saveFileName)
-          .attr("href", url)
-          .style("display", "none");
-
-      // Activate the download through a click event
-      a.node().click();
-
-      // Garbage collection
-      setTimeout(function() {
-        window.URL.revokeObjectURL(url);
-      }, 10);
-    });
-}
-
-// When the "Download PNG" link is clicked, download the visualizations
-$('#downloadLinkPNG').click(function() {
-  downloadVisualizations(dlPNG);
-});
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// PRINT CODE
-//
-function printVisualization(viz) {
-  if (viz == SAVEJS_CONST.CNA_VIZ) {
-    saveSVG('cnas', SAVEJS_FNAMES.CNA_VIZ).print();
-  }
-  if (viz == SAVEJS_CONST.ABERRS) {
-    saveSVG('aberrations', SAVEJS_FNAMES.ABERRS).print();
-  }
-  if (viz == SAVEJS_CONST.SUB_NET) {
-    saveSVG('network', SAVEJS_FNAMES.SUB_NET).print();
-  }
-  if (viz == SAVEJS_CONST.TRN_ANT) {
-    saveSVG('transcript', SAVEJS_FNAMES.TRN_ANT).print();
-  }
-  if (viz == SAVEJS_CONST.HMP_VIZ) {
-    saveSVG('heatmap', SAVEJS_FNAMES.HMP_VIZ).print();
-  }
-}
-
-$('#printCnaViz').click(function(e) {
-  e.preventDefault();
-  printVisualization(SAVEJS_CONST.CNA_VIZ);
-});
-$('#printAberrs').click(function(e) {
-  e.preventDefault();
-  printVisualization(SAVEJS_CONST.ABERRS);
-});
-$('#printSubNet').click(function(e) {
-  e.preventDefault();
-  printVisualization(SAVEJS_CONST.SUB_NET);
-});
-$('#printTrnAnt').click(function(e) {
-  e.preventDefault();
-  printVisualization(SAVEJS_CONST.TRN_ANT);
-});
-$('#printHmpViz').click(function(e) {
-  e.preventDefault();
-  printVisualization(SAVEJS_CONST.HMP_VIZ);
+  });
 });

--- a/public/js/view.js
+++ b/public/js/view.js
@@ -580,17 +580,15 @@ function view(){
 			return { name: d, color: datasetToColor[d], numSamples: datasetToSamples[d].length };
 		}).sort(function(a, b){ return d3.ascending(a.name, b.name); });
 
-  var datasetsTbl = d3.select("table#datasets tbody");
-	var datasetRows = datasetsTbl.selectAll('.tr')
-    .data(datasetData).enter()
-    .append("tr")
+	var datasetRows = d3.selectAll("table#datasets tbody tr")
     .on("click", function(d){
       // Add/Remove the dataset from the list of filtered datasets
-			var index = filteredDatasets.indexOf(d.name),
+      var name = $(this).data('name');
+			var index = filteredDatasets.indexOf(name),
 				visible = index == -1;
 
 			if (visible){
-				filteredDatasets.push( d.name );
+				filteredDatasets.push( name );
 			} else{
 				filteredDatasets.splice(index, 1);
 			}
@@ -602,9 +600,9 @@ function view(){
 			d3.select(this).style("opacity", visible ? 0.5 : 1);
     });
 
-	datasetRows.append("td").append("div").attr("class", "dataset-color").style("background", function(d){ return d.color; });
-  datasetRows.append("td").text(function(d){ return d.name; });
-  datasetRows.append("td").text(function(d){ return d.numSamples; });
+	// datasetRows.append("td").append("div").attr("class", "dataset-color").style("background", function(d){ return d.color; });
+  // datasetRows.append("td").text(function(d){ console.log(d); return d.name; });
+  // datasetRows.append("td").text(function(d){ return d.numSamples; });
 
 	///////////////////////////////////////////////////////////////////////////
 	// Add controls

--- a/public/js/view.js
+++ b/public/js/view.js
@@ -49,7 +49,8 @@ function view(){
 		transcriptSelectElement = "select#transcript-select",
 		cnasElement = "div#cnas",
 		cnasSelectElement = "select#cnas-select",
-		controlsElement = "div#control-panel div#controls",
+    // controlsElement = "div#control-panel div#controls",
+    controlsElement = "div#controls",
 		annotateInputElement = "div#annotation div#inputs",
 		annotatedGeneElement = "div#annotation select#gene",
 		interactionElement = "div#annotation select#interaction",
@@ -300,15 +301,15 @@ function view(){
 					cancerNames.forEach(function(name) {
 					    numRefs += cancerToRefs[name].length;
 					});
-					tooltipData.push({ type: 'link', 
+					tooltipData.push({ type: 'link',
 							   body: 'View references (' + numRefs +') for this gene',
 							   href: annotationsURL + '/annotations/' + geneName}); // todo: limit to references to a mutation
 					tooltipData.push(tooltipNewline); // workaround: add newline after a link
 				    }
 				}
-			    tooltipData.push({ type: 'link', 
+			    tooltipData.push({ type: 'link',
 					       body: 'Add a new reference for this gene',
-					       href: annotationsURL + '/annotations/create/mutation/?gene=' + geneName}); 
+					       href: annotationsURL + '/annotations/create/mutation/?gene=' + geneName});
 			    tooltipData.push(tooltipNewline);
 
 			}
@@ -354,7 +355,7 @@ function view(){
 					refTable.push([
 						{type: 'text', text: i ? "" : n},
 						{type: 'link', href: pubmedLink(ref.pmid), body: ref.pmid},
-			
+
 					].map(gd3.tooltip.datum));
 				})
 			} else {
@@ -363,20 +364,20 @@ function view(){
 		});
 
 // todo: remove vote buttons
-	    createInteractionHref = annotationsURL + '/annotations/interactions/add/?source=' + d.source.name + 
-			'&target=' + d.target.name; 
+	    createInteractionHref = annotationsURL + '/annotations/interactions/add/?source=' + d.source.name +
+			'&target=' + d.target.name;
 
 		// Add the tooltip
 		networkTooltips.push([
 		    { type: 'text', text: 'Source: ' + d.source.name },
 		    { type: 'text', text: 'Target: ' + d.target.name },
-		    { type: 'link', 
-		      href: annotationsURL + '/annotations/interactions/' + d.source.name + ',' + d.target.name, 
+		    { type: 'link',
+		      href: annotationsURL + '/annotations/interactions/' + d.source.name + ',' + d.target.name,
 		      body: 'View references to this interaction.'},
 		    tooltipNewline,
-		    { type: 'link', 
-		      href: createInteractionHref, 
-		      body: 'Add and/or annotate a reference to this interaction.'}, 
+		    { type: 'link',
+		      href: createInteractionHref,
+		      body: 'Add and/or annotate a reference to this interaction.'},
 		    { type: 'table', table: refTable }
 		].map(gd3.tooltip.datum) );
 	});
@@ -446,7 +447,7 @@ function view(){
 				clause2 = geneName + '%5Btw%5D+AND+(' + changeOneCode + "+OR+" + changeThreeCode + ")",
 				changeQuery = clause1 + " OR (" + clause2 + ")",
 		    changeHref = 'http://www.ncbi.nlm.nih.gov/pmc/?term=' + changeQuery;
-	    
+
 		    createParams = {'gene': geneName,
 				    'mutation_class': 'SNV',
 				    'mutation_type': mutationTypeRevMap[d.ty],
@@ -455,7 +456,7 @@ function view(){
 				    'new_amino_acid': d.aan,
 				    'cancer': d.dataset.toLowerCase()};		    // FIXME: database != cancer for some datasets
 
-		    createMutationHref = annotationsURL + '/annotations/save/mutation/?' + $.param(createParams);  
+		    createMutationHref = annotationsURL + '/annotations/save/mutation/?' + $.param(createParams);
 
 			transcriptTooltips.push([
 			    { type: 'link', href: '/sampleView?sample=' + d.sample, body: 'Sample: ' + d.sample },
@@ -466,7 +467,7 @@ function view(){
 			    tooltipNewline,
 			    { type: 'link', href: changeHref, body: 'Search protein sequence change on Pubmed.' },
 			    tooltipNewline,
-			    { type: 'link', href: annotationsURL + '/annotations/' + geneName, body: 'View all references to this mutation'}, 
+			    { type: 'link', href: annotationsURL + '/annotations/' + geneName, body: 'View all references to this mutation'},
 			    tooltipNewline,
 			    { type: 'link', href: createMutationHref, body: 'Add and/or annotate a reference to this mutation.' },
 			].map(gd3.tooltip.datum));
@@ -579,44 +580,12 @@ function view(){
 			return { name: d, color: datasetToColor[d], numSamples: datasetToSamples[d].length };
 		}).sort(function(a, b){ return d3.ascending(a.name, b.name); });
 
-	// Add a container and a heading
-	var controls = d3.select("#control-panel div#controls"),
-		datasetsPanel = controls.append("div")
-			.attr("class", "panel panel-default")
-			.style("padding", "0px")
-
-	var datasetHeading = datasetsPanel.append("div")
-		.attr("class", "panel-heading")
-		.style("padding", "5px")
-		.append("h5")
-		.attr("class", "panel-title")
-		.attr("id", "datasetLink")
-		.style("cursor", "pointer")
-		.style("font-size", "14px")
-		.style("width", "100%")
-		.text("Datasets");
-	bootstrapToggle({link: "dataset", target: "Dataset"});
-
-	datasetHeading.append("span")
-		.style("float", "right")
-		.text("[+]");
-
-	// Add each dataset
-	var datasetsBody = datasetsPanel.append("div")
-		.attr("id", "collapseDataset")
-		.attr("class", "panel-collapse collapse in")
-		.append("div")
-		.attr("class", "panel-body")
-		.style("padding", "5px");
-
-	var datasetEls = datasetsBody.append("ul")
-		.attr("id", "datasets")
-		.selectAll(".dataset")
-		.data(datasetData).enter()
-		.append("li")
-		.style("cursor", "pointer")
-		.on("click", function(d){
-			// Add/Remove the dataset from the list of filtered datasets
+  var datasetsTbl = d3.select("table#datasets tbody");
+	var datasetRows = datasetsTbl.selectAll('.tr')
+    .data(datasetData).enter()
+    .append("tr")
+    .on("click", function(d){
+      // Add/Remove the dataset from the list of filtered datasets
 			var index = filteredDatasets.indexOf(d.name),
 				visible = index == -1;
 
@@ -631,10 +600,11 @@ function view(){
 
 			// Fade in/out this dataset
 			d3.select(this).style("opacity", visible ? 0.5 : 1);
-		});
+    });
 
-	datasetEls.append("div").attr("class", "dataset-color").style("background", function(d){ return d.color; });
-	datasetEls.append("div").text(function(d){ return d.name + " (" + d.numSamples + ")"; });
+	datasetRows.append("td").append("div").attr("class", "dataset-color").style("background", function(d){ return d.color; });
+  datasetRows.append("td").text(function(d){ return d.name; });
+  datasetRows.append("td").text(function(d){ return d.numSamples; });
 
 	///////////////////////////////////////////////////////////////////////////
 	// Add controls

--- a/routes/router.js
+++ b/routes/router.js
@@ -10,7 +10,8 @@ var about = require( './about' ),
 	annotations = require('./annotations'),
   log = require('./log'),
   share = require('./share'),
-  requery = require('./requery');
+  requery = require('./requery'),
+	save = require('./save');
 
 //*  Export the routes in each subrouter *//
 
@@ -62,6 +63,9 @@ exports.datasets = {};
 exports.datasets.index = datasets.index;
 exports.datasets.view = datasets.view;
 exports.datasets.manifests = datasets.manifests;
+
+// Save
+exports.savefigure = save.figure;
 
 // Share link
 exports.saveShareURL = share.saveShareURL;

--- a/routes/save.js
+++ b/routes/save.js
@@ -1,0 +1,59 @@
+// Handle save figure requests
+var Q = require('q');
+var fs = require('fs');
+var childProcess = require('child_process');
+var path = require('path');
+
+// CONSTANTS
+var tmpdir = path.normalize(path.join(__dirname + '/../tmp/'));
+var fileName = 'figure';
+var svgFileName = fileName + '.svg';
+var svgFilePath = tmpdir + svgFileName;
+var supportedExtensions = ['pdf', 'png', 'svg'];
+
+// Use a call librsvg to convert the input (SVG) file to the given format
+function convertFile(inputFile, outputFile, format){
+  // Set up the system command to use rsvg-convert to convert the file
+  var d = Q.defer();
+  var msg, err = "", output = "";
+  var cmd = 'rsvg-convert -f ' + format + ' -o ' + outputFile + ' ' + inputFile;
+
+  // Execute the child process
+  child = childProcess.exec(cmd);
+  child.on('stdout', function(stdout){ output += stdout; });
+  child.on('stderr', function(stderr){ err += stderr; });
+  child.on('close', function(closeCode) { code = closeCode; });
+  child.on('exit', function (exitCode) {
+    console.log('Exit code:', exitCode)
+    d.resolve();
+  });
+
+  return d.promise;
+}
+
+// Main route for saving and converting a figure
+exports.figure = function (req, res) {
+  if (req.body !== undefined && req.body.svg !== undefined){
+    if (supportedExtensions.indexOf(req.body.format) !== -1){
+      var outputFileName = fileName + '.' + req.body.format;
+      fs.writeFile(svgFilePath, req.body.svg, function(err){
+        if (err) return console.log(err);
+
+        // Just send the SVG if that's what they want
+        if (req.body.format === 'svg'){
+          res.setHeader('Content-disposition', 'attachment; filename=' + svgFileName);
+          res.sendFile(svgFilePath);
+        // Otherwise, convert the file, then return it
+        } else {
+          var imgFilePath = tmpdir + outputFileName;
+          convertFile(svgFilePath, imgFilePath, req.body.format).then(function(){
+            res.setHeader('Content-disposition', 'attachment; filename=' + outputFileName);
+            res.sendFile(imgFilePath);
+          });
+        }
+      });
+    } else{
+      res.json({error: 'Format "' + req.body.format + '" not supported.'})
+    }
+  }
+}

--- a/routes/view.js
+++ b/routes/view.js
@@ -218,9 +218,9 @@ exports.view  = function view(req, res){
 								geneToAnnotationList = {},
 								geneToAnnotationCount = {};
 
-						genes.forEach(function(g){ 
+						genes.forEach(function(g){
 							annotations[g] = {};
-							geneToAnnotationCount[g] = 0; 
+							geneToAnnotationCount[g] = 0;
 							geneToAnnotationList[g] = {};
 						})
 						support.rows.forEach(function(A, i){
@@ -237,8 +237,8 @@ exports.view  = function view(req, res){
 							if (!annotations[A.gene_id][A.mutation_class][A.cancer_name]) {
 								annotations[A.gene_id][A.mutation_class][A.cancer_name] = [];
 							}
-							annotations[A.gene_id][A.mutation_class][A.cancer_name].push(ref); 
-							geneToAnnotationCount[A.gene_id] += 1; 
+							annotations[A.gene_id][A.mutation_class][A.cancer_name].push(ref);
+							geneToAnnotationCount[A.gene_id] += 1;
 						});
 
 						// Assemble data into single Object
@@ -301,6 +301,7 @@ exports.view  = function view(req, res){
 										title: "Mutations"
 									    };
 									    var pkg = {
+												datasets: datasets.sort(function(a, b){ return a.title > b.title ? 1 : -1; }),
 										abbrToCancer: abbrToCancer,
 										datasetToCancer: datasetToCancer,
 										network: network_data,

--- a/server.js
+++ b/server.js
@@ -197,6 +197,9 @@ app.get('/logout', routes.logout);
 app.get('/account', ensureAuthenticated, routes.account);
 app.post('/user/update', ensureAuthenticated, routes.user.update);
 
+// Save image response functions
+app.post('/save-figure', routes.savefigure);
+
 // Render errors
 app.get("/401", function(req, res){
   var msg = req.session.msg401;
@@ -272,48 +275,6 @@ function ensureAuthenticated(req, res, next) {
     req.session.returnTo = req.path;
     res.redirect('/login');
   }
-}
-
-/**
- * Save image response functions
- */
-
-// Handle save figure requests
-app.post('/saveSVG', function(req, res) {
-  if(req.body.html !== undefined) {
-    res.send(req.body.html);
-  } else if (req.body.img !== undefined) {
-    res.writeHead(200, {'Content-Type': 'image/png' });
-    res.end(req.body.img, 'binary');
-    res.send();
-  }
-});
-
-// Not needed as of the moment; delete if not needed for PDF generation
-function saveSVG(req, res) {
-  var bowerDir = 'public/components/',
-      fileName = req.body.fileName,
-      svgHTML = req.body.html;
-
-  // run the jsdom headless browser
-  var runHeadless = function (errors, window) {
-    var svg = window.d3.select('svg');
-    svg.attr('xmlns', 'http://www.w3.org/2000/svg')
-         .attr('xmlns:xlink','http://www.w3.org/1999/xlink');
-    var svgNode = svg.node();
-
-    res.setHeader('Content-Disposition', 'attachment');
-    res.setHeader('Content-type', 'application/pdf');//'image/svg+xml');
-
-    res.send('complete');
-
-    console.log('----');
-    console.log((svgNode.outerHTML).substring(0, 120));
-    console.log('Size of svgNode: ' + Buffer.byteLength(svgNode.outerHTML, 'utf8') + " bytes");
-    console.log(typeof svgNode.outerHTML);
-  };
-
-  jsdom.env(svgHTML,[bowerDir+'d3/d3.js', bowerDir+'jquery/dist/jquery.js'], runHeadless);
 }
 
 /**

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -49,12 +49,10 @@ html
                       a(href="/support") Support
                     li
                       a(href="#" id="give-feedback") Feedback
-            ul(class="nav navbar-nav navbar-center")
-              li
-                div(style="padding-top:14px;margin-right:5px")
-                  | &nbsp;|&nbsp;
-                  a(href=annotationsURL target="_blank") 
-                    button(type="button" class="btn btn-danger btn-xs") MAGI Annotations
+                    li
+                      a(class="btn btn-danger", href=annotationsURL, target="_new", style="color:#fff")
+                        | MAGI annotations&nbsp;
+                        i(class="fa fa-external-link")
             ul(class="nav navbar-nav navbar-right", style="color:grey")
               li
                 //- Ask the user to login or show his/her name

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -5,6 +5,7 @@ html
     link(rel="icon", type="image/png", href="/img/favicon.png")
     title MAGI
     link(rel='stylesheet', href='/components/bootstrap/dist/css/bootstrap.min.css')
+    link(rel='stylesheet', href='/components/fontawesome/css/font-awesome.min.css')
     link(rel='stylesheet', href='/css/app.css')
     link(rel='stylesheet', href='/css/elusive-webfont.css')
 

--- a/views/view.jade
+++ b/views/view.jade
@@ -24,10 +24,22 @@ block body
                     table(class="table table-hover", id="datasets")
                       thead
                         tr
-                          th Color
+                          th
                           th Dataset
                           th Samples
+                          th View
                       tbody
+                        - for (var i = 0; i < data.datasets.length; i++)
+                          tr(data-name="#{data.datasets[i].title}")
+                            td
+                              div(class="dataset-color", style="background:#{data.datasets[i].color}")
+                            td
+                              span(style="border-bottom: 1px dotted #777;cursor:help", data-trigger="hover", data-placement="bottom", data-toggle="popover", data-content="#{data.datasetToCancer[data.datasets[i].title]}")
+                                | #{data.datasets[i].title}
+                            td #{data.datasets[i].samples.length}
+                            td
+                              a(href="/datasets/view/#{data.datasets[i]._id}")
+                                i(class="fa fa-external-link")
                       
                 div(class="panel panel-default")
                   div(class="panel-heading", role="tab")

--- a/views/view.jade
+++ b/views/view.jade
@@ -106,6 +106,27 @@ block body
                     | Aberrations
                   ul(class="list-inline pull-right")
                     li
+                      div(class="dropdown")
+                        a(class="fa fa-sort", title="Sort columns of aberrations matrix", id="aberrationsSort", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
+                        ul(class="dropdown-menu", aria-labelledby="aberrationsSort", id="sort-options")
+                          li(class="sort-option", data-sort-option="First active row")
+                            a
+                              i(class="fa fa-sort")
+                              span(class="sort-name") First active row
+                          li(class="sort-option", data-sort-option="Column category")
+                            a
+                              i(class="fa fa-sort")
+                              span(class="sort-name") Sample type
+                          li(class="sort-option", data-sort-option="Exclusivity")
+                              a
+                                i(class="fa fa-sort")
+                                span(class="sort-name") Exclusivity
+                          li(class="sort-option", data-sort-option="Name")
+                              a
+                                i(class="fa fa-sort")
+                                span(class="sort-name") Sample name
+                          
+                    li
                       a(class="fa fa-info", title="Aberrations view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the mutations of genes (rows) across samples (columns). Samples are colored by cancer type. Full ticks represent SNVs, downticks represent deletions, upticks represent amplifications, and triangles represent fusions, rearragements or splice variants. Only samples with a mutation in the given subnetwork are shown. You can <b>zoom in on and drag the mutation matrix</b> by scrolling and/or clicking the figure with your mouse.")
                     li
                       a(class="fa fa-question", title="Aberrations view tour")
@@ -290,6 +311,8 @@ block belowTheFold
       script(src='/js/save.js').
       script(src='/js/view.js').
       script(src='/js/log.js').
+      script(src='/js/log.js').
+      script(src='/components/jquery-ui/jquery-ui.min.js'). //- required for drag/drop list sorting
       //- Define behavior for the scroll panel to stick to the top of the window
       script(type="text/javascript").
         $(document).ready(function(){

--- a/views/view.jade
+++ b/views/view.jade
@@ -62,8 +62,9 @@ block body
                         - for (var i = 0; i < data.genes.length; i++)
                           tr(class="variant-annotations-row", data-href=annotationsURL + "/annotations/#{data.genes[i]}")
                             td #{data.genes[i]}
-                            td 
-                              span(class="badge") #{data.geneToAnnotationCount[data.genes[i]]}
+                            td
+                              span(class="pull-left badge") #{data.geneToAnnotationCount[data.genes[i]]}
+                              i(class="pull-right fa fa-external-link")
                 div(id="annotateMutation" class="panel panel-default")
                   div(class="panel-heading", role="tab", id="annotateMutationsHeading")
                     h4(class="panel-title", id="annotateMutationsLink")

--- a/views/view.jade
+++ b/views/view.jade
@@ -81,44 +81,7 @@ block body
                       h4(class="panel-title clearfix")
                         span(class="pull-left") Share
                         i(class="fa fa-share pull-right")
-                  
-              div(id="saveBox", class="panel panel-default", style="padding:0px")
-                div(class="panel-heading", style="padding:5px")
-                  h5(class="panel-title", style="cursor:pointer;font-size:14px;", id="saveLink")
-                    | Download views
-                    span(style="float:right") [+]
 
-                div(id="collapseSave", class="panel-collapse collapse", style="display:none")
-                  div(class="panel-body", style="padding:5px")
-                    p(style="margin:0px;") Select <a href="" id="saveSelectAll"> all</a> or <a href="" id="saveSelectNone">none</a>
-                    ul(id="saveOptList", style="padding:0px;list-style:none;")
-                      li
-                        label(style="font-weight:400")
-                          input(type="checkbox", id="aberrations-download", style="margin-right:5px;")
-                          | Aberrations
-                      li
-                        label(style="font-weight:400")
-                          input(type="checkbox", id="heatmap-download", style="margin-right:5px;")
-                          | Heatmap
-                      li
-                        label(style="font-weight:400")
-                          input(type="checkbox", id="network-download", style="margin-right:5px;")
-                          | Network
-                      li
-                        label(style="font-weight:400")
-                          input(type="checkbox", id="transcript-download", style="margin-right:5px;")
-                          | Transcript
-                      li
-                        label(style="font-weight:400")
-                          input(type="checkbox", id="cna-download", style="margin-right:5px;")
-                          | CNAs
-                    a(id="downloadLink", style="cursor:pointer")
-                      | &raquo; Download as SVG
-                    br
-                    a(id="downloadLinkPNG", style="cursor:pointer")
-                      | &raquo; Download as PNG
-
-                    div(id="saveErrMsgContainer")
         //- MAIN VIEWS
         div(class="col-lg-9 col-md-pull-3 col-md-9 col-sm-12 col-xs-12")
           //- Aberrations row

--- a/views/view.jade
+++ b/views/view.jade
@@ -5,233 +5,271 @@ block body
     h3 Loading...
     img(src="/img/spinner.gif")
   div(id="view-page")
-    div(id="control-panel")
-      h4 Control Panel <span id="hideControlPanel">[-]</span>
-      div(class="panel panel-default", style="margin-top:5px")
-        div(class="panel-heading", style="padding:5px")
-          a(href="#", id="enrichmentStatsLink", style="color:#000000")
-            h5(class="panel-title", style="cursor:pointer;font-size:14px;")
-              | Enrichment statistics
-              span(style="float:right") [+]
-      div(id="controls")
-
-      div(id="viz-options", class="panel panel-default")
-        div(class="panel-heading", style="padding:5px")
-          h5(class="panel-title", style="cursor:pointer;font-size:14px;", id="optionsLink")
-            | Show/hide views
-            span(style="float:right") [+]
-        div(id="collapseOptions", class="panel-collapse collapse", style="padding:5px")
-          b Hide views
-          ul(style="padding:0px;list-style:none")
-            li(class="checkbox")
-              label
-                input(type="checkbox", id="AberrationsHideCheckbox")
-                | Aberrations
-            li(class="checkbox")
-              label(style="font-weight:400")
-                input(type="checkbox", id="DataMatrixHideCheckbox")
-                | Heatmap
-            li(class="checkbox")
-              label
-                input(type="checkbox", id="NetworkTranscriptHideCheckbox")
-                | Network and transcript
-            li(class="checkbox")
-              label
-                input(type="checkbox", id="CNAsHideCheckbox")
-                | CNAs
-
-      div(id="saveBox", class="panel panel-default", style="padding:0px")
-        div(class="panel-heading", style="padding:5px")
-          h5(class="panel-title", style="cursor:pointer;font-size:14px;", id="saveLink")
-            | Download views
-            span(style="float:right") [+]
-
-        div(id="collapseSave", class="panel-collapse collapse")
-          div(class="panel-body", style="padding:5px")
-            p(style="margin:0px;") Select <a href="" id="saveSelectAll"> all</a> or <a href="" id="saveSelectNone">none</a>
-            ul(id="saveOptList", style="padding:0px;list-style:none;")
-              li
-                label(style="font-weight:400")
-                  input(type="checkbox", id="aberrations-download", style="margin-right:5px;")
-                  | Aberrations
-              li
-                label(style="font-weight:400")
-                  input(type="checkbox", id="heatmap-download", style="margin-right:5px;")
-                  | Heatmap
-              li
-                label(style="font-weight:400")
-                  input(type="checkbox", id="network-download", style="margin-right:5px;")
-                  | Network
-              li
-                label(style="font-weight:400")
-                  input(type="checkbox", id="transcript-download", style="margin-right:5px;")
-                  | Transcript
-              li
-                label(style="font-weight:400")
-                  input(type="checkbox", id="cna-download", style="margin-right:5px;")
-                  | CNAs
-            a(id="downloadLink", style="cursor:pointer")
-              | &raquo; Download as SVG
-            br
-            a(id="downloadLinkPNG", style="cursor:pointer")
-              | &raquo; Download as PNG
-
-            div(id="saveErrMsgContainer")
-
-      div(id="annotatedVariants" class="panel panel-default", style="padding:0px;")
-        div(class="panel-heading", style="padding:5px")
-          h5(class="panel-title", style="cursor:pointer;font-size:14px;", id="annotatedVariantsLink")
-            | Variant annotations
-            span(style="float:right") [+]
-
-        div(id="collapseAnnotatedVariants", class="panel-collapse collapse")
-          div(class="panel-body", style="padding:5px;font-size:90%")
-            ul
-              - for (var i = 0; i < data.genes.length; i++)
-                li
-                  | #{data.genes[i]}
-                  a(href= annotationsURL + "/annotations/#{data.genes[i]}" target="_new")
-                    span(class="badge", style="font-size:80%") #{data.geneToAnnotationCount[data.genes[i]]}
-
-      div(id="annotateMutation" class="panel panel-default", style="padding:0px;")
-        div(class="panel-heading", style="padding:5px")
-          h5(class="panel-title", style="cursor:pointer;font-size:14px;", id="annotateMutationLink")
-            | Annotate mutations
-            span(style="float:right") [+]
-
-        div(id="collapseMutationAnnotation", class="panel-collapse collapse in")
-          div(class="panel-body", style="padding:5px;font-size:90%")
-            | Annotate references to mutations  
-            a(href="/annotation/mutation/create", target="_blank") here
-            |  or by clicking on the link on the mutations popup within the transcript view.
-
-      div(id="annotateInteraction" class="panel panel-default", style="padding:0px;")
-        div(class="panel-heading", style="padding:5px")
-          h5(class="panel-title", style="cursor:pointer;font-size:14px;", id="annotateInteractionLink")
-            | Annotate interactions
-            span(style="float:right") [+]
-
-        div(id="collapseInteractionAnnotation", class="panel-collapse collapse in")
-          div(class="panel-body", style="padding:5px;font-size:90%")
-            | Annotate references to interactions 
-            a(href= annotationsURL + "/annotations/interactions/add" target="_blank") here
-            |  or by clicking on the link on the interactions popup within the network view.
-
-      div(id="share")
-        //- Button trigger modal
-        button(id="shareBtn", class="btn btn-primary btn-md", data-toggle="modal", data-target="#myModal") Share
-
-    div(id="instructions")
-      div(class="panel panel-default")
-        div(class="panel-heading")
-          h4(class="panel-title", data-toggle="collapse", data-target="#collapseOne", style="cursor:pointer", id="instructionsLink")
-            | INSTRUCTIONS
-            span(style="float:right") [+]
-
-        div(id="collapseOne", class="panel-collapse collapse")
-          div(class="panel-body")
-            ul
-              li
-                i
-                  b Network view.&nbsp;
-                | Shows the interactions among genes on the HINT, HPRD, or iRefIndex interaction networks.
-                | You can <b>toggle the interaction networks</b> shown by clicking on them in the legend,
-                | and you can <b>reposition the nodes </b>in the subnetwork for a better view by <b>dragging/dropping</b> them.
-              li
-                i
-                  b Aberrations view.&nbsp;
-                | Shows the mutations of genes (rows) across samples (columns). Samples are colored by cancer type.
-                | Full ticks represent SNVs, downticks represent deletions, upticks represent amplifications,
-                | and triangles represent fusions, rearragements or splice variants.
-                | Only samples with a mutation in the given subnetwork are shown.
-                | You can <b>zoom in on and drag the mutation matrix</b> by scrolling and/or clicking the figure with your mouse.
-              li
-                i
-                  b Heatmap view.&nbsp;
-                | Shows continuous-valued data in a query set of genes (rows) in a cohort of samples (columns) as heatmap.
-                | By default, displays expression data in only the samples in which the genes are mutated.
-              li
-                i
-                  b Transcript view.&nbsp;
-                | Shows the mutations in each REFSEQ transcript of each gene in the subnetwork.
-                | Mutations are colored by cancer type. Each symbol represents a distinct mutation type.
-                | Putatively inactivating mutations are shown below the transcript, and the remaining mutations are shown above the transcript.
-                | Select one of the three protein domain databases, including Pfam, SMART, and NCBI Conserve Domain, to show annotated protein domains for each transcript -- scroll over a domain to reveal its name.
-                | You can <b>zoom in on and drag the transcript annotation</b> by scrolling and/or clicking the figure with your mouse.
-              li
-                i
-                  b CNA view.&nbsp;
-                | Shows the copy number aberrations surrounding the selected gene (highlighted as red) on the chromosome.
-                | The topest panel shows genes (shown as blocks) distributed in the region.
-                | You can click and drag a window in this panel to zoom in and see the details in the middle and bottom panels.
-                | The middle and bottom panels show genes and copy number aberration inside the zoom in window you just dragged, respectively.
-                | Copy number aberrations are colored by cancer type.
-                | Each row represents one sample.
-                | You can mouseover copy number aberration to get more detail information.
-
     div(id="spinner")
-    div(id="view")
+    div(class="container", style="width:100%")
+      div(class="row")
+        //- MAIN VIEWS
+        div(class="col-lg-9")
+          //- Aberrations row
+          div(class="row")
+            div(class="col-lg-12")
+              div(id="aberrationsRow", class="panel panel-default")
+                div(class="panel-heading clearfix")
+                  h4(class="panel-title pull-left")
+                    | Aberrations
+                  ul(class="list-inline pull-right")
+                    li
+                      a(class="fa fa-info", title="Aberrations view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the mutations of genes (rows) across samples (columns). Samples are colored by cancer type. Full ticks represent SNVs, downticks represent deletions, upticks represent amplifications, and triangles represent fusions, rearragements or splice variants. Only samples with a mutation in the given subnetwork are shown. You can <b>zoom in on and drag the mutation matrix</b> by scrolling and/or clicking the figure with your mouse.")
+                    li
+                      a(class="fa fa-question", title="Aberrations view tour")
+                    li
+                      div(class="dropdown")
+                        a(class="fa fa-download dropdown-toggle", id="aberrationsDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
+                        ul(class="dropdown-menu", aria-labelledby="aberrationsDownload")
+                          li
+                            a(title="Download aberrations view as SVG") SVG
+                          li
+                            a(title="Download aberrations view as PNG") PNG
+                    li
+                      a(class="fa fa-print", title="Print aberrations view", id="printAberrs")
+                    li
+                      a(class="fa fa-caret-square-o-down collapse", title="Toggle aberrations view", data-toggle="collapse", data-target="#collapseAberrations", id="aberrationsLink")
 
-      div
-        div(id="aberrationsRow")
-          h3
-            | Aberrations
-            small
-              | &nbsp;&nbsp;
-              a(id="printAberrs", title="Print aberrations view.")
-                  span(class="glyphicon glyphicon-print")
-          div(id="aberrations")
-          br
-        //- Heatmap view
-        div(id="dataMatrixRow")
-          h3(id="heatmap-title")
-              span(class="name") Heatmap
-              small(style="font-size:12px")
-                | &nbsp;&nbsp;
-                a(id="printHmpViz", title="Print heatmap.")
-                    span(class="glyphicon glyphicon-print")
-          div(id="heatmap")
+                div(id="collapseAberrations", class="panel-collapse collapse in")
+                  div(id="aberrations", class="panel-body")
 
+          //- Heatmap row
+          div(class="row")
+            div(class="col-lg-12")
+              div(id="dataMatrixRow", class="panel panel-default")
+                div(class="panel-heading clearfix")
+                  h4(class="panel-title pull-left")
+                    | Heatmap
+                  ul(class="list-inline pull-right")
+                    li
+                      a(class="fa fa-info", title="Heatmap description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows continuous-valued data in a query set of genes (rows) in a cohort of samples (columns) as heatmap. By default, displays expression data in only the samples in which the genes are mutated.")
+                    li
+                      a(class="fa fa-question", title="Heatmap tour")
+                    li
+                      div(class="dropdown")
+                        a(class="fa fa-download dropdown-toggle", id="heatmapDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
+                        ul(class="dropdown-menu", aria-labelledby="heatmapDownload")
+                          li
+                            a(title="Download heatmap view as SVG") SVG
+                          li
+                            a(title="Download heatmap view as PNG") PNG
+                    li
+                      a(class="fa fa-print", title="Print heatmap", id="printHmpViz")
+                    li
+                      a(class="fa fa-caret-square-o-down collapse", title="Toggle heatmap", data-toggle="collapse", data-target="#collapseHeatmap", id="heatmapLink")
+                            
+                div(id="collapseHeatmap", class="panel-collapse collapse in")
+                  div(id="heatmap", class="panel-body")
 
-      hr(style="margin:0px;")
+          //- Network and transcript row
+          div(class="row", id="networkTranscriptRow")
+            //- Network view
+            div(class="col-lg-6")
+              div(class="panel panel-default")
+                div(class="panel-heading clearfix")
+                  h4(class="panel-title pull-left")
+                    | Network
+                  ul(class="list-inline pull-right")
+                    li
+                      a(class="fa fa-info", title="Network view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the interactions among genes on the HINT, HPRD, or iRefIndex interaction networks. You can <b>toggle the interaction networks</b> shown by clicking on them in the legend, and you can <b>reposition the nodes </b>in the subnetwork for a better view by <b>dragging/dropping</b> them.")
+                    li
+                      a(class="fa fa-question", title="Network view tour")
+                    li
+                      div(class="dropdown")
+                        a(class="fa fa-download dropdown-toggle", id="networkDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
+                        ul(class="dropdown-menu", aria-labelledby="networkDownload")
+                          li
+                            a(title="Download network view as SVG") SVG
+                          li
+                            a(title="Download network view as PNG") PNG
+                    li
+                      a(class="fa fa-print", title="Print network view", id="printSubNet")
+                    li
+                      a(class="fa fa-caret-square-o-down collapse", title="Toggle network view", data-toggle="collapse", data-target="#collapseNetwork", id="networkLink")
 
-      div(id="networkTranscriptRow")
-        div(class="half-page-view leftside")
-            h3
-              | Network
-              small(style="font-size:12px")
-                | &nbsp;&nbsp;
-                a(id="printSubNet", title="Print network.")
-                    span(class="glyphicon glyphicon-print")
-            div(id="network")
+                div(id="collapseNetwork", class="panel-collapse collapse in")
+                  div(id="network", class="panel-body")
+            
+            //- Transcript view
+            div(class="col-lg-6")
+              div(class="panel panel-default")
+                div(class="panel-heading clearfix")
+                  h4(class="panel-title pull-left")
+                    | Transcript
+                  ul(class="list-inline pull-right")
+                    li
+                      a(class="fa fa-info", title="Transcript view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the mutations in each REFSEQ transcript of each gene in the subnetwork. Mutations are colored by cancer type. Each symbol represents a distinct mutation type. Putatively inactivating mutations are shown below the transcript, and the remaining mutations are shown above the transcript. Select one of the three protein domain databases, including Pfam, SMART, and NCBI Conserve Domain, to show annotated protein domains for each transcript -- scroll over a domain to reveal its name. You can <b>zoom in on and drag the transcript annotation</b> by scrolling and/or clicking the figure with your mouse.")
+                    li
+                      a(class="fa fa-question", title="Transcript view tour")
+                    li
+                      div(class="dropdown")
+                        a(class="fa fa-download dropdown-toggle", id="transcriptDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
+                        ul(class="dropdown-menu", aria-labelledby="transcriptDownload")
+                          li
+                            a(title="Download transcript view as SVG") SVG
+                          li
+                            a(title="Download transcript view as PNG") PNG
+                    li
+                      a(class="fa fa-print", title="Print transcript view", id="printTrnAnt")
+                    li
+                      a(class="fa fa-caret-square-o-down collapse", title="Toggle transcript view", data-toggle="collapse", data-target="#collapseTranscript", id="transcriptLink")
 
-        div(class="half-page-view rightside")
-            h3
-              | Transcript
-              small
-                | &nbsp;&nbsp;
-                a(id="printTrnAnt", title="Print transcript view.")
-                    span(class="glyphicon glyphicon-print")
-            select(class="form-control", id="transcript-select")
-            div(id="transcript")
+                div(id="collapseTranscript", class="panel-collapse collapse in")
+                  div(class="panel-body")
+                    select(class="form-control", id="transcript-select")
+                    div(id="transcript")
 
-      hr(style="clear:both;margin:0px;")
+          //- CNAs row
+          div(class="row", id="cnasRow")
+            div(class="col-lg-12")
+              div(class="panel panel-default")
+                div(class="panel-heading clearfix")
+                  h4(class="panel-title pull-left")
+                    | Copy Number Aberrations
+                  ul(class="list-inline pull-right")
+                    li
+                      a(class="fa fa-info", title="CNA view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the copy number aberrations surrounding the selected gene (highlighted as red) on the chromosome. The topest panel shows genes (shown as blocks) distributed in the region. You can click and drag a window in this panel to zoom in and see the details in the middle and bottom panels. The middle and bottom panels show genes and copy number aberration inside the zoom in window you just dragged, respectively. Copy number aberrations are colored by cancer type. Each row represents one sample. You can mouseover copy number aberration to get more detail information.")
+                    li
+                      a(class="fa fa-question", title="CNA view tour")
+                    li
+                      div(class="dropdown")
+                        a(class="fa fa-download dropdown-toggle", id="cnaDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
+                        ul(class="dropdown-menu", aria-labelledby="cnaDownload")
+                          li
+                            a(title="Download CNA view as SVG") SVG
+                          li
+                            a(title="Download CNA view as PNG") PNG
+                    li
+                      a(class="fa fa-print", title="Print CNA view", id="printCnaViz")
+                    li
+                      a(class="fa fa-caret-square-o-down collapse", data-toggle="collapse", data-target="#collapseCNAs", id="cnasLink")
 
-      //- CNA view
-      div(id="cnasRow")
-        h3
-          | Copy number aberrations
-          small
-            | &nbsp;&nbsp;
-            a(id="printCnaViz", title="Print CNA view.")
-                span(class="glyphicon glyphicon-print")
+                div(id="collapseCNAs", class="panel-collapse collapse in")
+                  div(class="panel-body")
+                    select(class="form-control", id="cnas-select")
+                    div(id="cnas")
 
-        select(class="form-control", id="cnas-select")
-        div(id="cnas")
+        //- CONTROL PANEL
+        div(class="col-lg-3")
+          div(id="controls", class="panel panel-default")
+            div(class="panel-heading")
+              h4(class="panel-title") Control Panel
+            div(class="panel-body")
+              div(class="panel-group" id="accordion" role="tablist" aria-multiselectable="true")
+                div(class="panel panel-primary")
+                  div(class="panel-heading" role="tab" id="datasetsHeading")
+                    h5(class="panel-title")
+                      a(role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDatasets" aria-expanded="true" aria-controls="collapseDatasets")
+                        | Datasets
+                  div(id="collapseDatasets" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="datasetsHeading")
+                    table(class="table table-hover", id="datasets")
+                      thead
+                        tr
+                          th Color
+                          th Dataset
+                          th Samples
+                      tbody
+                      
+                div(class="panel panel-primary")
+                  div(class="panel-heading", role="tab")
+                    h4(class="panel-title")
+                      a(id="enrichmentStatsLink", class="clearfix")
+                        span(class="pull-left") Enrichment statistics&nbsp;
+                        i(class="pull-right fa fa-external-link")
+                div(class="panel panel-primary")
+                  div(class="panel-heading" role="tab" id="variantAnnotationsHeading")
+                    h4(class="panel-title")
+                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseVariantAnnotations" aria-expanded="false" aria-controls="collapseVariantAnnotations")
+                        | Variant annotations
+                  div(id="collapseVariantAnnotations" class="panel-collapse collapse" role="tabpanel" aria-labelledby="variantAnnotationsHeading")
+                    table(class="table table-hover")
+                      thead
+                        tr(style="background:rgb(51,51,51);color:#ffffff")
+                          th Gene
+                          th Annotations
+                      tbody
+                        - for (var i = 0; i < data.genes.length; i++)
+                          tr(class="variant-annotations-row", data-href=annotationsURL + "/annotations/#{data.genes[i]}")
+                            td #{data.genes[i]}
+                            td 
+                              span(class="badge") #{data.geneToAnnotationCount[data.genes[i]]}
+                div(id="annotateMutation" class="panel panel-primary")
+                  div(class="panel-heading", role="tab", id="annotateMutationsHeading")
+                    h4(class="panel-title", id="annotateMutationsLink")
+                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseMutationAnnotation" aria-expanded="false" aria-controls="collapseMutationAnnotation")
+                        | Annotate mutations
 
+                  div(id="collapseMutationAnnotation", class="panel-collapse collapse" role="tabpanel" aria-labelledby="annotateMutationsHeading")
+                    div(class="panel-body")
+                      | Annotate references to mutations  
+                      a(href="/annotation/mutation/create", target="_blank") here
+                      |  or by clicking on the link on the mutations popup within the transcript view.
+
+                div(id="annotateInteraction" class="panel panel-primary")
+                  div(class="panel-heading", role="tab", id="annotateInteractionsHeading")
+                    h4(class="panel-title", id="annotateInteractionsLink")
+                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseInteractionAnnotation" aria-expanded="false" aria-controls="collapseInteractionAnnotation")
+                        | Annotate interactions
+
+                  div(id="collapseInteractionAnnotation", class="panel-collapse collapse", role="tabpanel", aria-labelledby="annotateInteractionsHeading")
+                    div(class="panel-body")
+                      | Annotate references to interactions 
+                      a(href= annotationsURL + "/annotations/interactions/add" target="_blank") here
+                      |  or by clicking on the link on the interactions popup within the network view.
+                div(id="share", class="panel panel-primary")
+                  div(class="panel-heading", role="tab", id="shareHeading")
+                    h4(class="panel-title clearfix", style="cursor:pointer")
+                      a(id="shareBtn", data-toggle="modal", data-target="#myModal")
+                        span(class="pull-left") Share
+                        i(class="fa fa-share pull-right")
+                  
+              div(id="saveBox", class="panel panel-default", style="padding:0px")
+                div(class="panel-heading", style="padding:5px")
+                  h5(class="panel-title", style="cursor:pointer;font-size:14px;", id="saveLink")
+                    | Download views
+                    span(style="float:right") [+]
+
+                div(id="collapseSave", class="panel-collapse collapse", style="display:none")
+                  div(class="panel-body", style="padding:5px")
+                    p(style="margin:0px;") Select <a href="" id="saveSelectAll"> all</a> or <a href="" id="saveSelectNone">none</a>
+                    ul(id="saveOptList", style="padding:0px;list-style:none;")
+                      li
+                        label(style="font-weight:400")
+                          input(type="checkbox", id="aberrations-download", style="margin-right:5px;")
+                          | Aberrations
+                      li
+                        label(style="font-weight:400")
+                          input(type="checkbox", id="heatmap-download", style="margin-right:5px;")
+                          | Heatmap
+                      li
+                        label(style="font-weight:400")
+                          input(type="checkbox", id="network-download", style="margin-right:5px;")
+                          | Network
+                      li
+                        label(style="font-weight:400")
+                          input(type="checkbox", id="transcript-download", style="margin-right:5px;")
+                          | Transcript
+                      li
+                        label(style="font-weight:400")
+                          input(type="checkbox", id="cna-download", style="margin-right:5px;")
+                          | CNAs
+                    a(id="downloadLink", style="cursor:pointer")
+                      | &raquo; Download as SVG
+                    br
+                    a(id="downloadLinkPNG", style="cursor:pointer")
+                      | &raquo; Download as PNG
+
+                    div(id="saveErrMsgContainer")
+                  
   script(type="text/javascript").
     var data = !{JSON.stringify(data)},
-        showDuplicates = !{showDuplicates};
+        showDuplicates = !{showDuplicates},
+        annotationsURL = !{JSON.stringify(annotationsURL)};
 
   //- Convert the user data to make it accessible to any javascript
   - if (user)
@@ -265,34 +303,18 @@ block belowTheFold
       script(src='/js/log.js').
       //- Define behavior for the scroll panel to stick to the top of the window
       script(type="text/javascript").
-        annotationsURL = !{JSON.stringify(annotationsURL)};
         $(document).ready(function(){
-          var jControlPanel = $('#control-panel');
-          $(window).bind('scroll', function() {
-            if ($(window).scrollTop() > navbarHeight) {
-              jControlPanel.addClass('fixed').css("position", "fixed").css("top", 0);
-            }
-            else {
-              jControlPanel.css("top", navbarHeight + 5 - $(window).scrollTop());
-              jControlPanel.removeClass('fixed').css("position", "fixed");
-            }
+          $('[data-toggle="popover"]').popover();
+          $('a.collapse').click(function(){
+            $( this ).toggleClass( "fa-caret-square-o-down" );
+            $( this ).toggleClass( "fa-caret-square-o-up" );
+          });
+          $('.variant-annotations-row').click(function(){
+            window.open($(this).data("href"));
+          });
+          //- Append this page's query parameters to create the enrichments link
+          $("#enrichmentStatsLink").attr("href", "/enrichments?" + window.location.href.split("?")[1]);
+          $('.btn-navbar').click( function() {
+            $('div#sidebar').toggleClass('expanded');
           });
         });
-        //- Set up bootstrap toggling
-        var linksWithToggles = [{link: "instructions", target: "One"},
-                                {link: "save", target: "Save"},
-                                {link: "voteComment", target: "VoteComment"},
-                                {link: "annotateMutation", target: "MutationAnnotation"},
-                                {link: "annotateInteraction", target: "InteractionAnnotation"},
-                                {link: "annotatedVariants", target: "AnnotatedVariants"},
-                                {link: "options", target: "Options"}];
-        function bootstrapToggle(d){
-          $("#" + d.link + "Link").click(function(e){
-              e.preventDefault();
-              e.stopPropagation();// prevent the default anchor functionality
-              $("#collapse" + d.target).collapse('toggle');
-            });
-        }
-        linksWithToggles.forEach(bootstrapToggle);
-        //- Append this page's query parameters to create the enrichments link
-        $("#enrichmentStatsLink").attr("href", "/enrichments?" + window.location.href.split("?")[1]);

--- a/views/view.jade
+++ b/views/view.jade
@@ -10,12 +10,12 @@ block body
       div(class="row")
         //- CONTROL PANEL
         div(class="col-lg-3 col-md-push-9 col-md-3 col-sm-12 col-xs-12")
-          div(data-spy="affix", data-offset-top="0", id="controls", class="panel panel-default")
+          div(data-spy="affix", data-offset-top="0", id="controls", class="panel panel-primary", style="max-width:400px")
             div(class="panel-heading")
               h4(class="panel-title") Control Panel
             div(class="panel-body")
               div(class="panel-group" id="accordion" role="tablist" aria-multiselectable="true")
-                div(class="panel panel-primary")
+                div(class="panel panel-default")
                   div(class="panel-heading" role="tab" id="datasetsHeading")
                     h5(class="panel-title")
                       a(role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDatasets" aria-expanded="true" aria-controls="collapseDatasets")
@@ -29,13 +29,13 @@ block body
                           th Samples
                       tbody
                       
-                div(class="panel panel-primary")
+                div(class="panel panel-default")
                   div(class="panel-heading", role="tab")
                     h4(class="panel-title")
                       a(id="enrichmentStatsLink", class="clearfix")
                         span(class="pull-left") Enrichment statistics&nbsp;
                         i(class="pull-right fa fa-external-link")
-                div(class="panel panel-primary")
+                div(class="panel panel-default")
                   div(class="panel-heading" role="tab" id="variantAnnotationsHeading")
                     h4(class="panel-title")
                       a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseVariantAnnotations" aria-expanded="false" aria-controls="collapseVariantAnnotations")
@@ -52,7 +52,7 @@ block body
                             td #{data.genes[i]}
                             td 
                               span(class="badge") #{data.geneToAnnotationCount[data.genes[i]]}
-                div(id="annotateMutation" class="panel panel-primary")
+                div(id="annotateMutation" class="panel panel-default")
                   div(class="panel-heading", role="tab", id="annotateMutationsHeading")
                     h4(class="panel-title", id="annotateMutationsLink")
                       a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseMutationAnnotation" aria-expanded="false" aria-controls="collapseMutationAnnotation")
@@ -64,7 +64,7 @@ block body
                       a(href="/annotation/mutation/create", target="_blank") here
                       |  or by clicking on the link on the mutations popup within the transcript view.
 
-                div(id="annotateInteraction" class="panel panel-primary")
+                div(id="annotateInteraction" class="panel panel-default")
                   div(class="panel-heading", role="tab", id="annotateInteractionsHeading")
                     h4(class="panel-title", id="annotateInteractionsLink")
                       a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseInteractionAnnotation" aria-expanded="false" aria-controls="collapseInteractionAnnotation")
@@ -75,9 +75,9 @@ block body
                       | Annotate references to interactions 
                       a(href= annotationsURL + "/annotations/interactions/add" target="_blank") here
                       |  or by clicking on the link on the interactions popup within the network view.
-                div(id="share", class="panel panel-primary")
+                div(id="share", class="panel panel-default")
                   div(class="panel-heading", role="tab", id="shareHeading")
-                    a(id="shareBtn", data-toggle="modal", data-target="#myModal", style="color:#fff;cursor:pointer")
+                    a(id="shareBtn", data-toggle="modal", data-target="#myModal", style="color:rgb(51,51,51);cursor:pointer")
                       h4(class="panel-title clearfix")
                         span(class="pull-left") Share
                         i(class="fa fa-share pull-right")

--- a/views/view.jade
+++ b/views/view.jade
@@ -217,7 +217,7 @@ block body
                     | Transcript
                   ul(class="list-inline pull-right")
                     li
-                      a(class="fa fa-info", title="Transcript view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the mutations in each REFSEQ transcript of each gene in the subnetwork. Mutations are colored by cancer type. Each symbol represents a distinct mutation type. Putatively inactivating mutations are shown below the transcript, and the remaining mutations are shown above the transcript. Select one of the three protein domain databases, including Pfam, SMART, and NCBI Conserve Domain, to show annotated protein domains for each transcript -- scroll over a domain to reveal its name. You can <b>zoom in on and drag the transcript annotation</b> by scrolling and/or clicking the figure with your mouse.")
+                      a(class="fa fa-info", title="Transcript view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the mutations in each REFSEQ transcript of each gene in the subnetwork. Mutations are colored by cancer type. Each symbol represents a distinct mutation type. Putatively inactivating mutations are shown below the transcript, and the remaining mutations are shown above the transcript. Annotated protein domains are shown for each transcript -- scroll over a domain to reveal its name. You can <b>zoom in on and drag the transcript annotation</b> by scrolling and/or clicking the figure with your mouse.")
                     li
                       a(class="fa fa-question", title="Transcript view tour")
                     li
@@ -249,7 +249,7 @@ block body
                     | Copy Number Aberrations
                   ul(class="list-inline pull-right")
                     li
-                      a(class="fa fa-info", title="CNA view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the copy number aberrations surrounding the selected gene (highlighted as red) on the chromosome. The topest panel shows genes (shown as blocks) distributed in the region. You can click and drag a window in this panel to zoom in and see the details in the middle and bottom panels. The middle and bottom panels show genes and copy number aberration inside the zoom in window you just dragged, respectively. Copy number aberrations are colored by cancer type. Each row represents one sample. You can mouseover copy number aberration to get more detail information.")
+                      a(class="fa fa-info", title="CNA view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the copy number aberrations surrounding the selected gene (highlighted as red) on the chromosome. The topmost panel shows genes (shown as blocks) distributed in the region. You can click and drag a window in this panel to zoom in and see the details in the middle and bottom panels. The middle and bottom panels show genes and copy number aberration inside the zoom in window you just dragged, respectively. Copy number aberrations are colored by cancer type. Each row represents one sample. You can mouseover copy number aberration to get more detail information.")
                     li
                       a(class="fa fa-question", title="CNA view tour")
                     li

--- a/views/view.jade
+++ b/views/view.jade
@@ -138,11 +138,13 @@ block body
                         a(class="fa fa-download dropdown-toggle", id="aberrationsDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
                         ul(class="dropdown-menu", aria-labelledby="aberrationsDownload")
                           li
-                            a(title="Download aberrations view as SVG") SVG
+                            a(class="save-figure-link", data-format="pdf", data-selector="aberrations", title="Download aberrations view as PDF") PDF
                           li
-                            a(title="Download aberrations view as PNG") PNG
+                            a(class="save-figure-link", data-format="png", data-selector="aberrations", title="Download aberrations view as PNG") PNG
+                          li
+                            a(class="save-figure-link", data-format="svg", data-selector="aberrations", title="Download aberrations view as SVG") SVG
                     li
-                      a(class="fa fa-print", title="Print aberrations view", id="printAberrs")
+                      a(class="print-figure-link fa fa-print", data-selector="aberrations", title="Print aberrations view", id="printAberrs")
                     li
                       a(class="fa fa-caret-square-o-down collapse", title="Toggle aberrations view", data-toggle="collapse", data-target="#collapseAberrations", id="aberrationsLink")
 
@@ -166,11 +168,13 @@ block body
                         a(class="fa fa-download dropdown-toggle", id="heatmapDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
                         ul(class="dropdown-menu", aria-labelledby="heatmapDownload")
                           li
-                            a(title="Download heatmap view as SVG") SVG
+                            a(class="save-figure-link", data-format="pdf", data-selector="heatmap", title="Download heatmap view as PDF") PDF
                           li
-                            a(title="Download heatmap view as PNG") PNG
+                            a(class="save-figure-link", data-format="png", data-selector="heatmap", title="Download heatmap view as PNG") PNG
+                          li
+                            a(class="save-figure-link", data-format="svg", data-selector="heatmap", title="Download heatmap view as SVG") SVG
                     li
-                      a(class="fa fa-print", title="Print heatmap", id="printHmpViz")
+                      a(class="print-figure-link fa fa-print", data-selector="heatmap", title="Print heatmap", id="printHmpViz")
                     li
                       a(class="fa fa-caret-square-o-down collapse", title="Toggle heatmap", data-toggle="collapse", data-target="#collapseHeatmap", id="heatmapLink")
                             
@@ -195,11 +199,13 @@ block body
                         a(class="fa fa-download dropdown-toggle", id="networkDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
                         ul(class="dropdown-menu", aria-labelledby="networkDownload")
                           li
-                            a(title="Download network view as SVG") SVG
+                            a(class="save-figure-link", data-format="pdf", data-selector="network", title="Download network view as PDF") PDF
                           li
-                            a(title="Download network view as PNG") PNG
+                            a(class="save-figure-link", data-format="png", data-selector="network", title="Download network view as PNG") PNG
+                          li
+                            a(class="save-figure-link", data-format="svg", data-selector="network", title="Download network view as SVG") SVG
                     li
-                      a(class="fa fa-print", title="Print network view", id="printSubNet")
+                      a(class="print-figure-link fa fa-print", data-selector="network", title="Print network view", id="printSubNet")
                     li
                       a(class="fa fa-caret-square-o-down collapse", title="Toggle network view", data-toggle="collapse", data-target="#collapseNetwork", id="networkLink")
 
@@ -222,11 +228,13 @@ block body
                         a(class="fa fa-download dropdown-toggle", id="transcriptDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
                         ul(class="dropdown-menu", aria-labelledby="transcriptDownload")
                           li
-                            a(title="Download transcript view as SVG") SVG
+                            a(class="save-figure-link", data-format="pdf", data-selector="transcript", title="Download transcript view as PDF") PDF
                           li
-                            a(title="Download transcript view as PNG") PNG
+                            a(class="save-figure-link", data-format="png", data-selector="transcript", title="Download transcript view as PNG") PNG
+                          li
+                            a(class="save-figure-link", data-format="svg", data-selector="transcript", title="Download transcript view as SVG") SVG
                     li
-                      a(class="fa fa-print", title="Print transcript view", id="printTrnAnt")
+                      a(class="print-figure-link fa fa-print", data-selector="transcript", title="Print transcript view")
                     li
                       a(class="fa fa-caret-square-o-down collapse", title="Toggle transcript view", data-toggle="collapse", data-target="#collapseTranscript", id="transcriptLink")
 
@@ -252,11 +260,13 @@ block body
                         a(class="fa fa-download dropdown-toggle", id="cnaDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
                         ul(class="dropdown-menu", aria-labelledby="cnaDownload")
                           li
-                            a(title="Download CNA view as SVG") SVG
+                            a(class="save-figure-link", data-format="pdf", data-selector="cnas", title="Download CNAs view as PDF") PDF
                           li
-                            a(title="Download CNA view as PNG") PNG
+                            a(class="save-figure-link", data-format="png", data-selector="cnas", title="Download CNAs view as PNG") PNG
+                          li
+                            a(class="save-figure-link", data-format="svg", data-selector="cnas", title="Download CNAs view as SVG") SVG
                     li
-                      a(class="fa fa-print", title="Print CNA view", id="printCnaViz")
+                      a(class="print-figure-link fa fa-print", data-selector="cnas", title="Print CNA view")
                     li
                       a(class="fa fa-caret-square-o-down collapse", data-toggle="collapse", data-target="#collapseCNAs", id="cnasLink")
 
@@ -277,6 +287,10 @@ block body
   - else
     script(type="text/javascript").
       var user = undefined;
+
+  form(id='save-figure', action='/save-figure', method='POST')
+    input(type='hidden', name='format', id='format')
+    input(type='hidden', name='svg', id='svg')
 
   //- Keep modal outside of the rest so it can't be in the background
   div(class="modal fade", id="myModal", tabindex="-1", role="dialog", aria-labelledby="myModalLabel", aria-hidden="true")

--- a/views/view.jade
+++ b/views/view.jade
@@ -8,8 +8,119 @@ block body
     div(id="spinner")
     div(class="container", style="width:100%")
       div(class="row")
+        //- CONTROL PANEL
+        div(class="col-lg-3 col-md-push-9 col-md-3 col-sm-12 col-xs-12")
+          div(data-spy="affix", data-offset-top="0", id="controls", class="panel panel-default")
+            div(class="panel-heading")
+              h4(class="panel-title") Control Panel
+            div(class="panel-body")
+              div(class="panel-group" id="accordion" role="tablist" aria-multiselectable="true")
+                div(class="panel panel-primary")
+                  div(class="panel-heading" role="tab" id="datasetsHeading")
+                    h5(class="panel-title")
+                      a(role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDatasets" aria-expanded="true" aria-controls="collapseDatasets")
+                        | Datasets
+                  div(id="collapseDatasets" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="datasetsHeading")
+                    table(class="table table-hover", id="datasets")
+                      thead
+                        tr
+                          th Color
+                          th Dataset
+                          th Samples
+                      tbody
+                      
+                div(class="panel panel-primary")
+                  div(class="panel-heading", role="tab")
+                    h4(class="panel-title")
+                      a(id="enrichmentStatsLink", class="clearfix")
+                        span(class="pull-left") Enrichment statistics&nbsp;
+                        i(class="pull-right fa fa-external-link")
+                div(class="panel panel-primary")
+                  div(class="panel-heading" role="tab" id="variantAnnotationsHeading")
+                    h4(class="panel-title")
+                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseVariantAnnotations" aria-expanded="false" aria-controls="collapseVariantAnnotations")
+                        | Variant annotations
+                  div(id="collapseVariantAnnotations" class="panel-collapse collapse" role="tabpanel" aria-labelledby="variantAnnotationsHeading")
+                    table(class="table table-hover")
+                      thead
+                        tr(style="background:rgb(51,51,51);color:#ffffff")
+                          th Gene
+                          th Annotations
+                      tbody
+                        - for (var i = 0; i < data.genes.length; i++)
+                          tr(class="variant-annotations-row", data-href=annotationsURL + "/annotations/#{data.genes[i]}")
+                            td #{data.genes[i]}
+                            td 
+                              span(class="badge") #{data.geneToAnnotationCount[data.genes[i]]}
+                div(id="annotateMutation" class="panel panel-primary")
+                  div(class="panel-heading", role="tab", id="annotateMutationsHeading")
+                    h4(class="panel-title", id="annotateMutationsLink")
+                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseMutationAnnotation" aria-expanded="false" aria-controls="collapseMutationAnnotation")
+                        | Annotate mutations
+
+                  div(id="collapseMutationAnnotation", class="panel-collapse collapse" role="tabpanel" aria-labelledby="annotateMutationsHeading")
+                    div(class="panel-body")
+                      | Annotate references to mutations  
+                      a(href="/annotation/mutation/create", target="_blank") here
+                      |  or by clicking on the link on the mutations popup within the transcript view.
+
+                div(id="annotateInteraction" class="panel panel-primary")
+                  div(class="panel-heading", role="tab", id="annotateInteractionsHeading")
+                    h4(class="panel-title", id="annotateInteractionsLink")
+                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseInteractionAnnotation" aria-expanded="false" aria-controls="collapseInteractionAnnotation")
+                        | Annotate interactions
+
+                  div(id="collapseInteractionAnnotation", class="panel-collapse collapse", role="tabpanel", aria-labelledby="annotateInteractionsHeading")
+                    div(class="panel-body")
+                      | Annotate references to interactions 
+                      a(href= annotationsURL + "/annotations/interactions/add" target="_blank") here
+                      |  or by clicking on the link on the interactions popup within the network view.
+                div(id="share", class="panel panel-primary")
+                  div(class="panel-heading", role="tab", id="shareHeading")
+                    a(id="shareBtn", data-toggle="modal", data-target="#myModal", style="color:#fff;cursor:pointer")
+                      h4(class="panel-title clearfix")
+                        span(class="pull-left") Share
+                        i(class="fa fa-share pull-right")
+                  
+              div(id="saveBox", class="panel panel-default", style="padding:0px")
+                div(class="panel-heading", style="padding:5px")
+                  h5(class="panel-title", style="cursor:pointer;font-size:14px;", id="saveLink")
+                    | Download views
+                    span(style="float:right") [+]
+
+                div(id="collapseSave", class="panel-collapse collapse", style="display:none")
+                  div(class="panel-body", style="padding:5px")
+                    p(style="margin:0px;") Select <a href="" id="saveSelectAll"> all</a> or <a href="" id="saveSelectNone">none</a>
+                    ul(id="saveOptList", style="padding:0px;list-style:none;")
+                      li
+                        label(style="font-weight:400")
+                          input(type="checkbox", id="aberrations-download", style="margin-right:5px;")
+                          | Aberrations
+                      li
+                        label(style="font-weight:400")
+                          input(type="checkbox", id="heatmap-download", style="margin-right:5px;")
+                          | Heatmap
+                      li
+                        label(style="font-weight:400")
+                          input(type="checkbox", id="network-download", style="margin-right:5px;")
+                          | Network
+                      li
+                        label(style="font-weight:400")
+                          input(type="checkbox", id="transcript-download", style="margin-right:5px;")
+                          | Transcript
+                      li
+                        label(style="font-weight:400")
+                          input(type="checkbox", id="cna-download", style="margin-right:5px;")
+                          | CNAs
+                    a(id="downloadLink", style="cursor:pointer")
+                      | &raquo; Download as SVG
+                    br
+                    a(id="downloadLinkPNG", style="cursor:pointer")
+                      | &raquo; Download as PNG
+
+                    div(id="saveErrMsgContainer")
         //- MAIN VIEWS
-        div(class="col-lg-9")
+        div(class="col-lg-9 col-md-pull-3 col-md-9 col-sm-12 col-xs-12")
           //- Aberrations row
           div(class="row")
             div(class="col-lg-12")
@@ -154,118 +265,6 @@ block body
                     select(class="form-control", id="cnas-select")
                     div(id="cnas")
 
-        //- CONTROL PANEL
-        div(class="col-lg-3")
-          div(id="controls", class="panel panel-default")
-            div(class="panel-heading")
-              h4(class="panel-title") Control Panel
-            div(class="panel-body")
-              div(class="panel-group" id="accordion" role="tablist" aria-multiselectable="true")
-                div(class="panel panel-primary")
-                  div(class="panel-heading" role="tab" id="datasetsHeading")
-                    h5(class="panel-title")
-                      a(role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDatasets" aria-expanded="true" aria-controls="collapseDatasets")
-                        | Datasets
-                  div(id="collapseDatasets" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="datasetsHeading")
-                    table(class="table table-hover", id="datasets")
-                      thead
-                        tr
-                          th Color
-                          th Dataset
-                          th Samples
-                      tbody
-                      
-                div(class="panel panel-primary")
-                  div(class="panel-heading", role="tab")
-                    h4(class="panel-title")
-                      a(id="enrichmentStatsLink", class="clearfix")
-                        span(class="pull-left") Enrichment statistics&nbsp;
-                        i(class="pull-right fa fa-external-link")
-                div(class="panel panel-primary")
-                  div(class="panel-heading" role="tab" id="variantAnnotationsHeading")
-                    h4(class="panel-title")
-                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseVariantAnnotations" aria-expanded="false" aria-controls="collapseVariantAnnotations")
-                        | Variant annotations
-                  div(id="collapseVariantAnnotations" class="panel-collapse collapse" role="tabpanel" aria-labelledby="variantAnnotationsHeading")
-                    table(class="table table-hover")
-                      thead
-                        tr(style="background:rgb(51,51,51);color:#ffffff")
-                          th Gene
-                          th Annotations
-                      tbody
-                        - for (var i = 0; i < data.genes.length; i++)
-                          tr(class="variant-annotations-row", data-href=annotationsURL + "/annotations/#{data.genes[i]}")
-                            td #{data.genes[i]}
-                            td 
-                              span(class="badge") #{data.geneToAnnotationCount[data.genes[i]]}
-                div(id="annotateMutation" class="panel panel-primary")
-                  div(class="panel-heading", role="tab", id="annotateMutationsHeading")
-                    h4(class="panel-title", id="annotateMutationsLink")
-                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseMutationAnnotation" aria-expanded="false" aria-controls="collapseMutationAnnotation")
-                        | Annotate mutations
-
-                  div(id="collapseMutationAnnotation", class="panel-collapse collapse" role="tabpanel" aria-labelledby="annotateMutationsHeading")
-                    div(class="panel-body")
-                      | Annotate references to mutations  
-                      a(href="/annotation/mutation/create", target="_blank") here
-                      |  or by clicking on the link on the mutations popup within the transcript view.
-
-                div(id="annotateInteraction" class="panel panel-primary")
-                  div(class="panel-heading", role="tab", id="annotateInteractionsHeading")
-                    h4(class="panel-title", id="annotateInteractionsLink")
-                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseInteractionAnnotation" aria-expanded="false" aria-controls="collapseInteractionAnnotation")
-                        | Annotate interactions
-
-                  div(id="collapseInteractionAnnotation", class="panel-collapse collapse", role="tabpanel", aria-labelledby="annotateInteractionsHeading")
-                    div(class="panel-body")
-                      | Annotate references to interactions 
-                      a(href= annotationsURL + "/annotations/interactions/add" target="_blank") here
-                      |  or by clicking on the link on the interactions popup within the network view.
-                div(id="share", class="panel panel-primary")
-                  div(class="panel-heading", role="tab", id="shareHeading")
-                    h4(class="panel-title clearfix", style="cursor:pointer")
-                      a(id="shareBtn", data-toggle="modal", data-target="#myModal")
-                        span(class="pull-left") Share
-                        i(class="fa fa-share pull-right")
-                  
-              div(id="saveBox", class="panel panel-default", style="padding:0px")
-                div(class="panel-heading", style="padding:5px")
-                  h5(class="panel-title", style="cursor:pointer;font-size:14px;", id="saveLink")
-                    | Download views
-                    span(style="float:right") [+]
-
-                div(id="collapseSave", class="panel-collapse collapse", style="display:none")
-                  div(class="panel-body", style="padding:5px")
-                    p(style="margin:0px;") Select <a href="" id="saveSelectAll"> all</a> or <a href="" id="saveSelectNone">none</a>
-                    ul(id="saveOptList", style="padding:0px;list-style:none;")
-                      li
-                        label(style="font-weight:400")
-                          input(type="checkbox", id="aberrations-download", style="margin-right:5px;")
-                          | Aberrations
-                      li
-                        label(style="font-weight:400")
-                          input(type="checkbox", id="heatmap-download", style="margin-right:5px;")
-                          | Heatmap
-                      li
-                        label(style="font-weight:400")
-                          input(type="checkbox", id="network-download", style="margin-right:5px;")
-                          | Network
-                      li
-                        label(style="font-weight:400")
-                          input(type="checkbox", id="transcript-download", style="margin-right:5px;")
-                          | Transcript
-                      li
-                        label(style="font-weight:400")
-                          input(type="checkbox", id="cna-download", style="margin-right:5px;")
-                          | CNAs
-                    a(id="downloadLink", style="cursor:pointer")
-                      | &raquo; Download as SVG
-                    br
-                    a(id="downloadLinkPNG", style="cursor:pointer")
-                      | &raquo; Download as PNG
-
-                    div(id="saveErrMsgContainer")
-                  
   script(type="text/javascript").
     var data = !{JSON.stringify(data)},
         showDuplicates = !{showDuplicates},
@@ -317,4 +316,11 @@ block belowTheFold
           $('.btn-navbar').click( function() {
             $('div#sidebar').toggleClass('expanded');
           });
+          //- Fix the affix causing width changes, as suggested here:
+          //- https://github.com/twbs/bootstrap/issues/10235
+          var $affix = $("div#controls"), 
+              $parent = $affix.parent(), 
+              resize = function() { $affix.width($parent.width()); };
+          $(window).resize(resize); 
+          resize();
         });


### PR DESCRIPTION
- Rewrite save to use librsvg to convert to PDF/PNG/SVG
- Simplify printing greatly using "data-" attributes in links
- Redesign of the five views, putting them in panels and adding common 
- Use grid layout for views/control panel, and fix control panel in place using Bootstrap's affix
- Add icons to control toggling, saving, printing, instructions, and (eventually) tours

Still to-do: implement tours for "?" icons
