### PR TITLE
Add custom layout support to MAGI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tmp/
 public/components/
 node_modules/
 backups/
+data/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -602,8 +602,10 @@ body:not(.shepherd-active) .container-index > * {
   #main-views { width: 100%; }
 }
 .fullWidthPanel, .halfWidthPanel {
+  background: white;
   border-right: 3px double #ccc;
-  min-width: 335px; /* arbitrary width to prevent header wrapping */
+  min-width: 350px; /* arbitrary width to prevent header wrapping */
 }
 .fullWidthPanel { width: 100%; }
 .halfWidthPanel { width: 50%; }
+.sortableHandle { cursor: move; }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -584,3 +584,21 @@ body:not(.shepherd-active) .container-index > * {
 
 /* D3-Tip styling from http://rawgit.com/Caged/d3-tip/master/examples/example-styles.css */
 .d3-tip {line-height: 1;font-weight: bold;padding: 12px;background: rgba(0, 0, 0, 0.8);color: #fff;border-radius: 2px;pointer-events: none;}/* Creates a small triangle extender for the tooltip */.d3-tip:after {box-sizing: border-box;display: inline;font-size: 10px;width: 100%;line-height: 1;color: rgba(0, 0, 0, 0.8);position: absolute;pointer-events: none;}/* Northward tooltips */.d3-tip.n:after {content: "\25BC";margin: -1px 0 0 0;top: 100%;left: 0;text-align: center;}/* Eastward tooltips */.d3-tip.e:after {content: "\25C0";margin: -4px 0 0 0;top: 50%;left: -8px;}/* Southward tooltips */.d3-tip.s:after {content: "\25B2";margin: 0 0 1px 0;top: -8px;left: 0;text-align: center;}/* Westward tooltips */.d3-tip.w:after {content: "\25B6";margin: -4px 0 0 -1px;top: 50%;left: 100%;}
+
+/* Draggable layout styles */
+#view-page {
+  width: 100%;
+}
+#main-views {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 15px;
+  width: calc(100% - 340px);
+}
+#controlPanel { float: right; width: 300px; }
+@media(max-width: 900px) {
+  #controlPanel { width: 100%; }
+  #main-views { width: 100%; }
+}
+.fullWidthPanel { width: 100%; }
+.halfWidthPanel { width: 50%; }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -426,7 +426,7 @@ div#view-page ul.list-inline a:hover{ text-decoration:none; color:#000000;}
 div#view-page ul#sort-options li div{display:block;padding:3px 20px 3px 20px;color:#999999;}
 div#view-page ul#sort-options li a span.sort-name{margin-left:5px;margin-right:5px;}
 
-div#main-views div.panel{ overflow-x:scroll;}
+div#main-views div.panel{ }
 
 /* Dataset summary page */
 div#dataset-summary div#left{ width:35%;display:table-cell;}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -601,5 +601,9 @@ body:not(.shepherd-active) .container-index > * {
   #controlPanel { width: 100%; }
   #main-views { width: 100%; }
 }
+.fullWidthPanel, .halfWidthPanel {
+  border-right: 3px double #ccc;
+  min-width: 335px; /* arbitrary width to prevent header wrapping */
+}
 .fullWidthPanel { width: 100%; }
 .halfWidthPanel { width: 50%; }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -596,6 +596,7 @@ body:not(.shepherd-active) .container-index > * {
   width: calc(100% - 340px);
 }
 #controlPanel { float: right; width: 300px; }
+#controlPanel div { z-index: 999; }
 @media(max-width: 900px) {
   #controlPanel { width: 100%; }
   #main-views { width: 100%; }

--- a/public/js/layout.js
+++ b/public/js/layout.js
@@ -19,4 +19,7 @@ function initResizableLayout() {
     clearTimeout(refreshThrottle);
     refreshThrottle = setTimeout(resizeEvent, 100);
   };
+
+  $( "#main-views" ).sortable({ handle: '.sortableHandle' });
+  $( "#main-views" ).disableSelection();
 }

--- a/public/js/layout.js
+++ b/public/js/layout.js
@@ -10,5 +10,13 @@ function initResizableLayout() {
     }
   });
 
-  console.log('hi');
+  function resizeEvent(){
+    Object.keys(VIEW_VIS_RENDER).forEach(function(k) { VIEW_VIS_RENDER[k](); });
+  }
+
+  var refreshThrottle;
+  window.onresize = function(){
+    clearTimeout(refreshThrottle);
+    refreshThrottle = setTimeout(resizeEvent, 100);
+  };
 }

--- a/public/js/layout.js
+++ b/public/js/layout.js
@@ -4,7 +4,10 @@ $(document).ready(initResizableLayout);
 function initResizableLayout() {
   $( ".panelResizable" ).resizable({
     handles: "e",
-    stop: function() { console.log('hi'); }
+    stop: function() {
+      var name = d3.select(this).attr("data-vis");
+      VIEW_VIS_RENDER[name](); // see view.js
+    }
   });
 
   console.log('hi');

--- a/public/js/layout.js
+++ b/public/js/layout.js
@@ -2,12 +2,20 @@
 $(document).ready(initResizableLayout);
 
 function initResizableLayout() {
-  $( ".panelResizable" ).resizable({
+  $( ".panelResizableE" ).resizable({
     handles: "e",
     stop: function() {
       var name = d3.select(this).attr("data-vis");
       VIEW_VIS_RENDER[name](); // see view.js
     }
+  });
+  $( ".panelResizableSE" ).resizable({
+    handles: "se",
+    stop: function() {
+      var name = d3.select(this).attr("data-vis");
+      VIEW_VIS_RENDER[name](); // see view.js
+    },
+    minHeight: 400
   });
 
   function resizeEvent(){

--- a/public/js/layout.js
+++ b/public/js/layout.js
@@ -1,0 +1,11 @@
+// Draggable layout controls for the query page
+$(document).ready(initResizableLayout);
+
+function initResizableLayout() {
+  $( ".panelResizable" ).resizable({
+    handles: "e",
+    stop: function() { console.log('hi'); }
+  });
+
+  console.log('hi');
+}

--- a/public/js/layout.js
+++ b/public/js/layout.js
@@ -20,6 +20,8 @@ function initResizableLayout() {
     refreshThrottle = setTimeout(resizeEvent, 100);
   };
 
-  $( "#main-views" ).sortable({ handle: '.sortableHandle' });
+  $( "#main-views" ).sortable({
+    handle: '.sortableHandle'
+  });
   $( "#main-views" ).disableSelection();
 }

--- a/public/js/view.js
+++ b/public/js/view.js
@@ -385,12 +385,8 @@ function drawNetwork() {
   var network = VIEW_COMPONENT_SELECTIONS.network;
   network.selectAll('*').remove();
   style.network.width = +network.style('width').replace('px','');
-  console.log(data.network);
   var valueExtent = d3.extent(data.network.nodes.map(function(d) { return d.value; }));
 
-  console.log(data.network)
-  console.log(style.network)
-  console.log(style)
   network.datum(data.network)
 		.call(gd3.graph({
 			style: style.network

--- a/public/js/view.js
+++ b/public/js/view.js
@@ -128,7 +128,7 @@ var VISUALIZATION_STYLE_DEFAULTS = {
     },
     sampleType: {}
   }
-}
+};
 
 var style = {
   aberrations: VISUALIZATION_STYLE_DEFAULTS,
@@ -137,7 +137,10 @@ var style = {
   network: VISUALIZATION_STYLE_DEFAULTS,
   transcript: VISUALIZATION_STYLE_DEFAULTS
 };
-
+// TODO refactor the style referencing so that this redundancy isn't needed
+Object.keys(VISUALIZATION_STYLE_DEFAULTS.colorSchemes.network).forEach(function(k) {
+  style.network[k] = VISUALIZATION_STYLE_DEFAULTS.colorSchemes.network[k];
+});
 
 function drawAberrationMatrix() {
   var aberrations = VIEW_COMPONENT_SELECTIONS.aberrations;
@@ -382,6 +385,12 @@ function drawNetwork() {
   var network = VIEW_COMPONENT_SELECTIONS.network;
   network.selectAll('*').remove();
   style.network.width = +network.style('width').replace('px','');
+  console.log(data.network);
+  var valueExtent = d3.extent(data.network.nodes.map(function(d) { return d.value; }));
+
+  console.log(data.network)
+  console.log(style.network)
+  console.log(style)
   network.datum(data.network)
 		.call(gd3.graph({
 			style: style.network

--- a/public/js/view.js
+++ b/public/js/view.js
@@ -301,7 +301,7 @@ function drawCNA() {
 			cnaTooltips.push([
 				{ type: 'link', href: '/sampleView?sample=' + d.sample, body: 'Sample: ' + d.sample },
 				{ type: 'text', text: 'Dataset: ' + d.dataset },
-				{ type: 'text', text: 'Type: ' + VIEW_util.mutationToName(d.ty) },
+				{ type: 'text', text: 'Type: ' + VIEW_UTIL.mutationToName(d.ty) },
 				{ type: 'text', text: 'Start: ' + d.start },
 				{ type: 'text', text: 'End: ' + d.end }
 			].map(gd3.tooltip.datum));

--- a/public/js/view.js
+++ b/public/js/view.js
@@ -89,6 +89,7 @@ var VIEW_UTIL = {
 	    else if (c=='null' || !c) return "Unknown";
 		else return c.toUpperCase();
   },
+  getHeight: function(selection) { return +selection.style('height').replace('px', ''); },
   mutationToName: function(m) {
     m = m.toLowerCase();
 		if (m == "snv") return "SNV";
@@ -382,10 +383,26 @@ function drawHeatmap() {
 }
 
 function drawNetwork() {
-  var network = VIEW_COMPONENT_SELECTIONS.network;
+  var network = VIEW_COMPONENT_SELECTIONS.network,
+      networkFirstRender = network.selectAll('*').empty(); // for height calc
+
   network.selectAll('*').remove();
   style.network.width = +network.style('width').replace('px','');
   var valueExtent = d3.extent(data.network.nodes.map(function(d) { return d.value; }));
+
+  if(networkFirstRender === false) {
+    var nnode = network.node()
+        networkPanel = d3.select(nnode.parentNode.parentNode),
+        networkPanelHeading = networkPanel.select('.panel-heading'),
+        networkH = VIEW_UTIL.getHeight(networkPanel) -
+                    VIEW_UTIL.getHeight(networkPanelHeading) -
+                    (+network.style('padding').replace('px',''));
+    console.log(VIEW_UTIL.getHeight(networkPanel), networkH, VIEW_UTIL.getHeight(network));
+    style.network.height = networkH
+  } else {
+    style.network.height = 300;
+  }
+
 
   network.datum(data.network)
 		.call(gd3.graph({
@@ -450,6 +467,22 @@ function drawTranscript() {
   // transcriptSelect.selectAll('*').remove();
 
   style.transcript.width = +transcript.style('width').replace('px','');
+  var transcriptPanelBody = d3.select('#transcript').node().parentNode,
+      transcriptPanel = d3.select(transcriptPanelBody.parentNode.parentNode),
+      transcriptPanelHeading = transcriptPanel.select('.panel-heading'),
+      transcriptSelectH = VIEW_UTIL.getHeight(transcriptSelect);
+
+  var transcriptPanelH = transcriptPanelHeadingH = undefined;
+  if(transcriptPanel.empty() === false)
+    transcriptPanelH = VIEW_UTIL.getHeight(transcriptPanel);
+  if(transcriptPanelHeading.empty() === false)
+    transcriptPanelHeadingH = VIEW_UTIL.getHeight(transcriptPanelHeading);
+
+  if(transcriptPanelH !== undefined && transcriptPanelHeadingH !== undefined) {
+    var padding = +d3.select(transcriptPanelBody).style('padding').replace('px','');
+    style.transcript.height = transcriptPanelH - transcriptPanelHeadingH - transcriptSelectH - padding*2 - 120;
+  }
+
 
   // First populate the dropdown with the transcripts for each gene
 	var numTranscriptsAdded = 0,

--- a/public/js/view.js
+++ b/public/js/view.js
@@ -223,7 +223,7 @@ function drawAberrationMatrix() {
 
 					// The table is hidden on default, so we show a string describing the
 					// table before showing it.
-				    var knownAberrations = cancerNames.map(cancerToName).filter(function(s) {return s != 'Unknown';}).join(", ");
+				    var knownAberrations = cancerNames.map(VIEW_UTIL.cancerToName).filter(function(s) {return s != 'Unknown';}).join(", ");
 				    var inKnownCancers = knownAberrations == '' ? '' : (' in ' + knownAberrations);
 				    tooltipData.push({ type: 'text', text: 'Known ' + mutationClass + inKnownCancers});
 				    // count the number of references
@@ -301,7 +301,7 @@ function drawCNA() {
 			cnaTooltips.push([
 				{ type: 'link', href: '/sampleView?sample=' + d.sample, body: 'Sample: ' + d.sample },
 				{ type: 'text', text: 'Dataset: ' + d.dataset },
-				{ type: 'text', text: 'Type: ' + mutationToName(d.ty) },
+				{ type: 'text', text: 'Type: ' + VIEW_util.mutationToName(d.ty) },
 				{ type: 'text', text: 'Start: ' + d.start },
 				{ type: 'text', text: 'End: ' + d.end }
 			].map(gd3.tooltip.datum));
@@ -408,7 +408,7 @@ function drawNetwork() {
 					// only show the network name in the first row
 					refTable.push([
 						{type: 'text', text: i ? "" : n},
-						{type: 'link', href: pubmedLink(ref.pmid), body: ref.pmid},
+						{type: 'link', href: VIEW_UTIL.pubmedLink(ref.pmid), body: ref.pmid},
                     ].map(gd3.tooltip.datum));
 				})
 			} else {

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -6,7 +6,7 @@ html
     title MAGI
     link(rel='stylesheet', href='/components/bootstrap/dist/css/bootstrap.min.css')
     link(rel='stylesheet', href='/components/fontawesome/css/font-awesome.min.css')
-    link(rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css")
+    link(rel="stylesheet" href="/components/jquery-ui/themes/base/jquery-ui.css")
     link(rel='stylesheet', href='/css/app.css')
     link(rel='stylesheet', href='/css/elusive-webfont.css')
 

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -6,6 +6,7 @@ html
     title MAGI
     link(rel='stylesheet', href='/components/bootstrap/dist/css/bootstrap.min.css')
     link(rel='stylesheet', href='/components/fontawesome/css/font-awesome.min.css')
+    link(rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css")
     link(rel='stylesheet', href='/css/app.css')
     link(rel='stylesheet', href='/css/elusive-webfont.css')
 

--- a/views/view.jade
+++ b/views/view.jade
@@ -96,7 +96,7 @@ block body
     //- MAIN VIEWS
     div(id="main-views")
           //- Aberrations row
-          div(class="panel panel-default panelResizable fullWidthPanel ui-state-default" data-vis="aberration")
+          div(class="panel panel-default panelResizableE fullWidthPanel ui-state-default" data-vis="aberration")
             div(class="panel-heading clearfix")
               h4(class="panel-title pull-left")
                 | <i class="fa fa-arrows sortableHandle" aria-hidden="true"></i> Aberrations
@@ -147,7 +147,7 @@ block body
               div(id="aberrations", class="panel-body")
 
           //- Heatmap row
-          div(class="panel panel-default panelResizable fullWidthPanel ui-state-default" data-vis="heatmap")
+          div(class="panel panel-default panelResizableE fullWidthPanel ui-state-default" data-vis="heatmap")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
                     | <i class="fa fa-arrows sortableHandle" aria-hidden="true"></i> Heatmap
@@ -175,7 +175,7 @@ block body
                   div(id="heatmap", class="panel-body")
 
           //- Network
-          div(class="panel panel-default panelResizable halfWidthPanel ui-state-default" data-vis="network")
+          div(class="panel panel-default panelResizableSE halfWidthPanel ui-state-default" data-vis="network")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
                     | <i class="fa fa-arrows sortableHandle" aria-hidden="true"></i> Network
@@ -203,7 +203,7 @@ block body
                   div(id="network", class="panel-body")
             
           //- Transcript view
-          div(class="panel panel-default panelResizable halfWidthPanel ui-state-default" data-vis="transcript")
+          div(class="panel panel-default panelResizableSE halfWidthPanel ui-state-default" data-vis="transcript")
             div(class="panel-heading clearfix")
               h4(class="panel-title pull-left")
                 | <i class="fa fa-arrows sortableHandle" aria-hidden="true"></i> Transcript
@@ -251,7 +251,7 @@ block body
                 div(id="transcript")
 
           //- CNAs row
-          div(class="panel panel-default panelResizable fullWidthPanel ui-state-default" data-vis="cna")
+          div(class="panel panel-default panelResizableE fullWidthPanel ui-state-default" data-vis="cna")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
                     | <i class="fa fa-arrows sortableHandle" aria-hidden="true"></i> Copy Number Aberrations

--- a/views/view.jade
+++ b/views/view.jade
@@ -315,7 +315,7 @@ block body
 block belowTheFold
       script(src="/components/gd3/gd3.js")
       script(src='/components/jquery-mousewheel/jquery.mousewheel.min.js'). // req for log.js
-      script(src="http://code.jquery.com/ui/1.10.0/jquery-ui.js"). // req for resizable layout
+      script(src="/components/jquery-ui/jquery-ui.js"). // req for resizable layout
       script(src='/components/jssha/src/sha1.js'). // req for log.js
       link(rel="stylesheet", href="/components/bootstrap-multiselect/dist/css/bootstrap-multiselect.css", type="text/css")
       link(rel="stylesheet", href="/components/tether-shepherd/dist/css/shepherd-theme-arrows.css", type="text/css")

--- a/views/view.jade
+++ b/views/view.jade
@@ -6,153 +6,148 @@ block body
     img(src="/img/spinner.gif")
   div(id="view-page")
     div(id="spinner")
-    div(class="container", style="width:100%")
-      div(class="row")
-        //- CONTROL PANEL
-        div(class="col-lg-3 col-md-push-9 col-md-3 col-sm-12 col-xs-12")
-          div(data-spy="affix", data-offset-top="0", id="controls", class="panel panel-primary", style="max-width:400px")
-            div(class="panel-heading")
-              h4(class="panel-title") Control Panel
-            div(class="panel-body")
-              div(class="panel-group" id="accordion" role="tablist" aria-multiselectable="true")
-                div(class="panel panel-default")
-                  div(class="panel-heading" role="tab" id="datasetsHeading")
-                    h5(class="panel-title")
-                      a(role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDatasets" aria-expanded="true" aria-controls="collapseDatasets")
-                        | Datasets
-                  div(id="collapseDatasets" class="panel-collapse collapse in table-responsive" role="tabpanel" aria-labelledby="datasetsHeading")
-                    table(class="table table-hover", id="datasets")
-                      thead
-                        tr
-                          th
-                          th Dataset
-                          th Samples
-                      tbody
-                        - for (var i = 0; i < data.datasets.length; i++)
-                          tr
-                            td(data-name="#{data.datasets[i].title}", class="dataset-color")
-                              div(style="background:#{data.datasets[i].color}")
-                            td
-                              span(style="border-bottom: 1px dotted #777;cursor:help", data-trigger="hover", data-placement="bottom", data-toggle="popover", data-content="#{data.datasetToCancer[data.datasets[i].title]}")
-                                | #{data.datasets[i].title}
-                            td(class="dataset-samples-cell")
-                                | #{data.datasets[i].samples.length}
-                                a(class="pull-right", href="/datasets/view/#{data.datasets[i]._id}")
-                                    i(class="fa fa-external-link")
-                      
-                div(class="panel panel-default")
-                  div(class="panel-heading", role="tab")
-                    h4(class="panel-title")
-                      a(id="enrichmentStatsLink", class="clearfix")
-                        span(class="pull-left") Enrichment statistics&nbsp;
-                        i(class="pull-right fa fa-external-link")
-                div(class="panel panel-default")
-                  div(class="panel-heading" role="tab" id="variantAnnotationsHeading")
-                    h4(class="panel-title")
-                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseVariantAnnotations" aria-expanded="false" aria-controls="collapseVariantAnnotations")
-                        | Variant annotations
-                  div(id="collapseVariantAnnotations" class="panel-collapse collapse" role="tabpanel" aria-labelledby="variantAnnotationsHeading")
-                    table(class="table table-hover")
-                      thead
-                        tr(style="background:rgb(51,51,51);color:#ffffff")
-                          th Gene
-                          th Annotations
-                      tbody
-                        - for (var i = 0; i < data.genes.length; i++)
-                          tr(class="variant-annotations-row", data-href=annotationsURL + "/annotations/#{data.genes[i]}")
-                            td #{data.genes[i]}
-                            td
-                              span(class="pull-left badge") #{data.geneToAnnotationCount[data.genes[i]]}
-                              i(class="pull-right fa fa-external-link")
-                div(id="annotateMutation" class="panel panel-default")
-                  div(class="panel-heading", role="tab", id="annotateMutationsHeading")
-                    h4(class="panel-title", id="annotateMutationsLink")
-                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseMutationAnnotation" aria-expanded="false" aria-controls="collapseMutationAnnotation")
-                        | Annotate mutations
 
-                  div(id="collapseMutationAnnotation", class="panel-collapse collapse" role="tabpanel" aria-labelledby="annotateMutationsHeading")
-                    div(class="panel-body")
-                      | Annotate references to mutations  
-                      a(href=annotationsURL + "/annotations/create/mutation", target="_blank") here
-                      |  or by clicking on the link on the mutations popup within the transcript view.
+    //- CONTROL PANEL
+    div(id="controlPanel")
+      div(data-spy="affix", data-offset-top="0", id="controls", class="panel panel-primary")
+        div(class="panel-heading")
+          h4(class="panel-title") Control Panel
+        div(class="panel-body")
+          div(class="panel-group" id="accordion" role="tablist" aria-multiselectable="true")
+            div(class="panel panel-default")
+              div(class="panel-heading" role="tab" id="datasetsHeading")
+                h5(class="panel-title")
+                  a(role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDatasets" aria-expanded="true" aria-controls="collapseDatasets")
+                    | Datasets
+              div(id="collapseDatasets" class="panel-collapse collapse in table-responsive" role="tabpanel" aria-labelledby="datasetsHeading")
+                table(class="table table-hover", id="datasets")
+                  thead
+                    tr
+                      th
+                      th Dataset
+                      th Samples
+                  tbody
+                    - for (var i = 0; i < data.datasets.length; i++)
+                      tr
+                        td(data-name="#{data.datasets[i].title}", class="dataset-color")
+                          div(style="background:#{data.datasets[i].color}")
+                        td
+                          span(style="border-bottom: 1px dotted #777;cursor:help", data-trigger="hover", data-placement="bottom", data-toggle="popover", data-content="#{data.datasetToCancer[data.datasets[i].title]}")
+                            | #{data.datasets[i].title}
+                        td(class="dataset-samples-cell")
+                            | #{data.datasets[i].samples.length}
+                            a(class="pull-right", href="/datasets/view/#{data.datasets[i]._id}")
+                                i(class="fa fa-external-link")
+                  
+            div(class="panel panel-default")
+              div(class="panel-heading", role="tab")
+                h4(class="panel-title")
+                  a(id="enrichmentStatsLink", class="clearfix")
+                    span(class="pull-left") Enrichment statistics&nbsp;
+                    i(class="pull-right fa fa-external-link")
+            div(class="panel panel-default")
+              div(class="panel-heading" role="tab" id="variantAnnotationsHeading")
+                h4(class="panel-title")
+                  a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseVariantAnnotations" aria-expanded="false" aria-controls="collapseVariantAnnotations")
+                    | Variant annotations
+              div(id="collapseVariantAnnotations" class="panel-collapse collapse" role="tabpanel" aria-labelledby="variantAnnotationsHeading")
+                table(class="table table-hover")
+                  thead
+                    tr(style="background:rgb(51,51,51);color:#ffffff")
+                      th Gene
+                      th Annotations
+                  tbody
+                    - for (var i = 0; i < data.genes.length; i++)
+                      tr(class="variant-annotations-row", data-href=annotationsURL + "/annotations/#{data.genes[i]}")
+                        td #{data.genes[i]}
+                        td
+                          span(class="pull-left badge") #{data.geneToAnnotationCount[data.genes[i]]}
+                          i(class="pull-right fa fa-external-link")
+            div(id="annotateMutation" class="panel panel-default")
+              div(class="panel-heading", role="tab", id="annotateMutationsHeading")
+                h4(class="panel-title", id="annotateMutationsLink")
+                  a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseMutationAnnotation" aria-expanded="false" aria-controls="collapseMutationAnnotation")
+                    | Annotate mutations
 
-                div(id="annotateInteraction" class="panel panel-default")
-                  div(class="panel-heading", role="tab", id="annotateInteractionsHeading")
-                    h4(class="panel-title", id="annotateInteractionsLink")
-                      a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseInteractionAnnotation" aria-expanded="false" aria-controls="collapseInteractionAnnotation")
-                        | Annotate interactions
+              div(id="collapseMutationAnnotation", class="panel-collapse collapse" role="tabpanel" aria-labelledby="annotateMutationsHeading")
+                div(class="panel-body")
+                  | Annotate references to mutations  
+                  a(href=annotationsURL + "/annotations/create/mutation", target="_blank") here
+                  |  or by clicking on the link on the mutations popup within the transcript view.
 
-                  div(id="collapseInteractionAnnotation", class="panel-collapse collapse", role="tabpanel", aria-labelledby="annotateInteractionsHeading")
-                    div(class="panel-body")
-                      | Annotate references to interactions 
-                      a(href= annotationsURL + "/annotations/interactions/add" target="_blank") here
-                      |  or by clicking on the link on the interactions popup within the network view.
-                div(id="share", class="panel panel-default")
-                  div(class="panel-heading", role="tab", id="shareHeading")
-                    a(id="shareBtn", data-toggle="modal", data-target="#myModal", style="color:rgb(51,51,51);cursor:pointer")
-                      h4(class="panel-title clearfix")
-                        span(class="pull-left") Share
-                        i(class="fa fa-share pull-right")
+            div(id="annotateInteraction" class="panel panel-default")
+              div(class="panel-heading", role="tab", id="annotateInteractionsHeading")
+                h4(class="panel-title", id="annotateInteractionsLink")
+                  a(class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseInteractionAnnotation" aria-expanded="false" aria-controls="collapseInteractionAnnotation")
+                    | Annotate interactions
 
-        //- MAIN VIEWS
-        div(id="main-views", class="col-lg-9 col-md-pull-3 col-md-9 col-sm-12 col-xs-12")
+              div(id="collapseInteractionAnnotation", class="panel-collapse collapse", role="tabpanel", aria-labelledby="annotateInteractionsHeading")
+                div(class="panel-body")
+                  | Annotate references to interactions 
+                  a(href= annotationsURL + "/annotations/interactions/add" target="_blank") here
+                  |  or by clicking on the link on the interactions popup within the network view.
+            div(id="share", class="panel panel-default")
+              div(class="panel-heading", role="tab", id="shareHeading")
+                a(id="shareBtn", data-toggle="modal", data-target="#myModal", style="color:rgb(51,51,51);cursor:pointer")
+                  h4(class="panel-title clearfix")
+                    span(class="pull-left") Share
+                    i(class="fa fa-share pull-right")
+
+    //- MAIN VIEWS
+    div(id="main-views")
           //- Aberrations row
-          div(class="row")
-            div(class="col-lg-12")
-              div(id="aberrationsRow", class="panel panel-default")
-                div(class="panel-heading clearfix")
-                  h4(class="panel-title pull-left")
-                    | Aberrations
-                  ul(class="list-inline pull-right")
-                    li
-                      div(class="dropdown")
-                        a(class="fa fa-sort", title="Sort columns of aberrations matrix", id="aberrationsSort", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
-                        ul(class="dropdown-menu", aria-labelledby="aberrationsSort", id="sort-options")
-                          li(class="dropdown-header")
-                            b DRAG AND DROP TO SORT
-                          li(class="sort-option", data-sort-option="First active row")
-                            a
-                              i(class="fa fa-sort")
-                              span(class="sort-name") First active row
-                          li(class="sort-option", data-sort-option="Column category")
-                            a
-                              i(class="fa fa-sort")
-                              span(class="sort-name") Sample type
-                          li(class="sort-option", data-sort-option="Exclusivity")
-                              a
-                                i(class="fa fa-sort")
-                                span(class="sort-name") Exclusivity
-                          li(class="sort-option", data-sort-option="Name")
-                              a
-                                i(class="fa fa-sort")
-                                span(class="sort-name") Sample name
-                          
-                    li
-                      a(class="fa fa-info", title="Aberrations view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the mutations of genes (rows) across samples (columns). Samples are colored by cancer type. Full ticks represent SNVs, downticks represent deletions, upticks represent amplifications, and triangles represent fusions, rearragements or splice variants. Only samples with a mutation in the given subnetwork are shown. You can <b>zoom in on and drag the mutation matrix</b> by scrolling and/or clicking the figure with your mouse.")
-                    li
-                      a(class="fa fa-question", id="aberrations-tour", title="Aberrations view tour")
-                    li
-                      div(class="dropdown")
-                        a(class="fa fa-download dropdown-toggle", id="aberrationsDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
-                        ul(class="dropdown-menu", aria-labelledby="aberrationsDownload")
-                          li
-                            a(class="save-figure-link", data-format="pdf", data-selector="aberrations", title="Download aberrations view as PDF") PDF
-                          li
-                            a(class="save-figure-link", data-format="png", data-selector="aberrations", title="Download aberrations view as PNG") PNG
-                          li
-                            a(class="save-figure-link", data-format="svg", data-selector="aberrations", title="Download aberrations view as SVG") SVG
-                    li
-                      a(class="print-figure-link fa fa-print", data-selector="aberrations", title="Print aberrations view", id="printAberrs")
-                    li
-                      a(class="fa fa-caret-square-o-down collapse", title="Toggle aberrations view", data-toggle="collapse", data-target="#collapseAberrations", id="aberrationsLink")
+          div(class="panel panel-default panelResizable fullWidthPanel")
+            div(class="panel-heading clearfix")
+              h4(class="panel-title pull-left")
+                | Aberrations
+              ul(class="list-inline pull-right")
+                li
+                  div(class="dropdown")
+                    a(class="fa fa-sort", title="Sort columns of aberrations matrix", id="aberrationsSort", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
+                    ul(class="dropdown-menu", aria-labelledby="aberrationsSort", id="sort-options")
+                      li(class="dropdown-header")
+                        b DRAG AND DROP TO SORT
+                      li(class="sort-option", data-sort-option="First active row")
+                        a
+                          i(class="fa fa-sort")
+                          span(class="sort-name") First active row
+                      li(class="sort-option", data-sort-option="Column category")
+                        a
+                          i(class="fa fa-sort")
+                          span(class="sort-name") Sample type
+                      li(class="sort-option", data-sort-option="Exclusivity")
+                          a
+                            i(class="fa fa-sort")
+                            span(class="sort-name") Exclusivity
+                      li(class="sort-option", data-sort-option="Name")
+                          a
+                            i(class="fa fa-sort")
+                            span(class="sort-name") Sample name
+                      
+                li
+                  a(class="fa fa-info", title="Aberrations view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the mutations of genes (rows) across samples (columns). Samples are colored by cancer type. Full ticks represent SNVs, downticks represent deletions, upticks represent amplifications, and triangles represent fusions, rearragements or splice variants. Only samples with a mutation in the given subnetwork are shown. You can <b>zoom in on and drag the mutation matrix</b> by scrolling and/or clicking the figure with your mouse.")
+                li
+                  a(class="fa fa-question", id="aberrations-tour", title="Aberrations view tour")
+                li
+                  div(class="dropdown")
+                    a(class="fa fa-download dropdown-toggle", id="aberrationsDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
+                    ul(class="dropdown-menu", aria-labelledby="aberrationsDownload")
+                      li
+                        a(class="save-figure-link", data-format="pdf", data-selector="aberrations", title="Download aberrations view as PDF") PDF
+                      li
+                        a(class="save-figure-link", data-format="png", data-selector="aberrations", title="Download aberrations view as PNG") PNG
+                      li
+                        a(class="save-figure-link", data-format="svg", data-selector="aberrations", title="Download aberrations view as SVG") SVG
+                li
+                  a(class="print-figure-link fa fa-print", data-selector="aberrations", title="Print aberrations view", id="printAberrs")
+                li
+                  a(class="fa fa-caret-square-o-down collapse", title="Toggle aberrations view", data-toggle="collapse", data-target="#collapseAberrations", id="aberrationsLink")
 
-                div(id="collapseAberrations", class="panel-collapse collapse in")
-                  div(id="aberrations", class="panel-body")
+            div(id="collapseAberrations", class="panel-collapse collapse in")
+              div(id="aberrations", class="panel-body")
 
           //- Heatmap row
-          div(class="row")
-            div(class="col-lg-12")
-              div(id="dataMatrixRow", class="panel panel-default")
+          div(class="panel panel-default panelResizable fullWidthPanel")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
                     | Heatmap
@@ -180,10 +175,7 @@ block body
                   div(id="heatmap", class="panel-body")
 
           //- Network and transcript row
-          div(class="row", id="networkTranscriptRow")
-            //- Network view
-            div(class="col-lg-6")
-              div(class="panel panel-default")
+          div(class="panel panel-default panelResizable halfWidthPanel")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
                     | Network
@@ -210,59 +202,56 @@ block body
                 div(id="collapseNetwork", class="panel-collapse collapse in")
                   div(id="network", class="panel-body")
             
-            //- Transcript view
-            div(class="col-lg-6")
-              div(class="panel panel-default")
-                div(class="panel-heading clearfix")
-                  h4(class="panel-title pull-left")
-                    | Transcript
-                  ul(class="list-inline pull-right")
-                    li
-                      div(class="dropdown")
-                        a(class="fa fa-cog", title="Choose which domain database to use", id="transcriptDomainDB", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
-                        ul(class="dropdown-menu", aria-labelledby="transcriptDomainDB", id="transcript-domain-radios")
-                          li(class="dropdown-header")
-                            b CHOOSE YOUR DOMAIN DATABASE
-                          li
-                            a
-                              input(type="radio", name="domainDB", value="CD")
-                              | &nbsp;CD 
-                          li
-                            a
-                              input(type="radio", name="domainDB", value="PFAM", checked="checked")
-                              | &nbsp;PFAM
-                          li
-                            a
-                              input(type="radio", name="domainDB", value="SMART")
-                              | &nbsp;SMART
-                    li
-                      a(class="fa fa-info", title="Transcript view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the mutations in each REFSEQ transcript of each gene in the subnetwork. Mutations are colored by cancer type. Each symbol represents a distinct mutation type. Putatively inactivating mutations are shown below the transcript, and the remaining mutations are shown above the transcript. Annotated protein domains are shown for each transcript -- scroll over a domain to reveal its name. You can <b>zoom in on and drag the transcript annotation</b> by scrolling and/or clicking the figure with your mouse.")
-                    li
-                      a(class="fa fa-question", id="transcript-tour", title="Transcript view tour")
-                    li
-                      div(class="dropdown")
-                        a(class="fa fa-download dropdown-toggle", id="transcriptDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
-                        ul(class="dropdown-menu", aria-labelledby="transcriptDownload")
-                          li
-                            a(class="save-figure-link", data-format="pdf", data-selector="transcript", title="Download transcript view as PDF") PDF
-                          li
-                            a(class="save-figure-link", data-format="png", data-selector="transcript", title="Download transcript view as PNG") PNG
-                          li
-                            a(class="save-figure-link", data-format="svg", data-selector="transcript", title="Download transcript view as SVG") SVG
-                    li
-                      a(class="print-figure-link fa fa-print", data-selector="transcript", title="Print transcript view")
-                    li
-                      a(class="fa fa-caret-square-o-down collapse", title="Toggle transcript view", data-toggle="collapse", data-target="#collapseTranscript", id="transcriptLink")
+          //- Transcript view
+          div(class="panel panel-default panelResizable halfWidthPanel")
+            div(class="panel-heading clearfix")
+              h4(class="panel-title pull-left")
+                | Transcript
+              ul(class="list-inline pull-right")
+                li
+                  div(class="dropdown")
+                    a(class="fa fa-cog", title="Choose which domain database to use", id="transcriptDomainDB", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
+                    ul(class="dropdown-menu", aria-labelledby="transcriptDomainDB", id="transcript-domain-radios")
+                      li(class="dropdown-header")
+                        b CHOOSE YOUR DOMAIN DATABASE
+                      li
+                        a
+                          input(type="radio", name="domainDB", value="CD")
+                          | &nbsp;CD 
+                      li
+                        a
+                          input(type="radio", name="domainDB", value="PFAM", checked="checked")
+                          | &nbsp;PFAM
+                      li
+                        a
+                          input(type="radio", name="domainDB", value="SMART")
+                          | &nbsp;SMART
+                li
+                  a(class="fa fa-info", title="Transcript view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the mutations in each REFSEQ transcript of each gene in the subnetwork. Mutations are colored by cancer type. Each symbol represents a distinct mutation type. Putatively inactivating mutations are shown below the transcript, and the remaining mutations are shown above the transcript. Annotated protein domains are shown for each transcript -- scroll over a domain to reveal its name. You can <b>zoom in on and drag the transcript annotation</b> by scrolling and/or clicking the figure with your mouse.")
+                li
+                  a(class="fa fa-question", id="transcript-tour", title="Transcript view tour")
+                li
+                  div(class="dropdown")
+                    a(class="fa fa-download dropdown-toggle", id="transcriptDownload", data-toggle="dropdown", aria-haspopup="true", aria-expanded="false")
+                    ul(class="dropdown-menu", aria-labelledby="transcriptDownload")
+                      li
+                        a(class="save-figure-link", data-format="pdf", data-selector="transcript", title="Download transcript view as PDF") PDF
+                      li
+                        a(class="save-figure-link", data-format="png", data-selector="transcript", title="Download transcript view as PNG") PNG
+                      li
+                        a(class="save-figure-link", data-format="svg", data-selector="transcript", title="Download transcript view as SVG") SVG
+                li
+                  a(class="print-figure-link fa fa-print", data-selector="transcript", title="Print transcript view")
+                li
+                  a(class="fa fa-caret-square-o-down collapse", title="Toggle transcript view", data-toggle="collapse", data-target="#collapseTranscript", id="transcriptLink")
 
-                div(id="collapseTranscript", class="panel-collapse collapse in")
-                  div(class="panel-body")
-                    select(class="form-control", id="transcript-select")
-                    div(id="transcript")
+            div(id="collapseTranscript", class="panel-collapse collapse in")
+              div(class="panel-body")
+                select(class="form-control", id="transcript-select")
+                div(id="transcript")
 
           //- CNAs row
-          div(class="row", id="cnasRow")
-            div(class="col-lg-12")
-              div(class="panel panel-default")
+          div(class="panel panel-default panelResizable fullWidthPanel")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
                     | Copy Number Aberrations
@@ -326,6 +315,7 @@ block body
 block belowTheFold
       script(src="/components/gd3/gd3.js")
       script(src='/components/jquery-mousewheel/jquery.mousewheel.min.js'). // req for log.js
+      script(src="http://code.jquery.com/ui/1.10.0/jquery-ui.js"). // req for resizable layout
       script(src='/components/jssha/src/sha1.js'). // req for log.js
       link(rel="stylesheet", href="/components/bootstrap-multiselect/dist/css/bootstrap-multiselect.css", type="text/css")
       link(rel="stylesheet", href="/components/tether-shepherd/dist/css/shepherd-theme-arrows.css", type="text/css")
@@ -333,6 +323,7 @@ block belowTheFold
       script(src='components/tether-shepherd/dist/js/shepherd.min.js').
       script(src='/js/save.js').
       script(src='/js/view.js').
+      script(src="/js/layout.js").
       script(src='/js/log.js').
       script(src='/js/log.js').
       script(src='/components/jquery-ui/jquery-ui.min.js'). //- required for drag/drop list sorting

--- a/views/view.jade
+++ b/views/view.jade
@@ -96,10 +96,10 @@ block body
     //- MAIN VIEWS
     div(id="main-views")
           //- Aberrations row
-          div(class="panel panel-default panelResizable fullWidthPanel" data-vis="aberration")
+          div(class="panel panel-default panelResizable fullWidthPanel ui-state-default" data-vis="aberration")
             div(class="panel-heading clearfix")
               h4(class="panel-title pull-left")
-                | Aberrations
+                | <i class="fa fa-arrows sortableHandle" aria-hidden="true"></i> Aberrations
               ul(class="list-inline pull-right")
                 li
                   div(class="dropdown")
@@ -147,10 +147,10 @@ block body
               div(id="aberrations", class="panel-body")
 
           //- Heatmap row
-          div(class="panel panel-default panelResizable fullWidthPanel" data-vis="heatmap")
+          div(class="panel panel-default panelResizable fullWidthPanel ui-state-default" data-vis="heatmap")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
-                    | Heatmap
+                    | <i class="fa fa-arrows sortableHandle" aria-hidden="true"></i> Heatmap
                   ul(class="list-inline pull-right")
                     li
                       a(class="fa fa-info", title="Heatmap description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows continuous-valued data in a query set of genes (rows) in a cohort of samples (columns) as heatmap. By default, displays expression data in only the samples in which the genes are mutated.")
@@ -175,10 +175,10 @@ block body
                   div(id="heatmap", class="panel-body")
 
           //- Network
-          div(class="panel panel-default panelResizable halfWidthPanel" data-vis="network")
+          div(class="panel panel-default panelResizable halfWidthPanel ui-state-default" data-vis="network")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
-                    | Network
+                    | <i class="fa fa-arrows sortableHandle" aria-hidden="true"></i> Network
                   ul(class="list-inline pull-right")
                     li
                       a(class="fa fa-info", title="Network view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the interactions among genes on the HINT, HPRD, or iRefIndex interaction networks. You can <b>toggle the interaction networks</b> shown by clicking on them in the legend, and you can <b>reposition the nodes </b>in the subnetwork for a better view by <b>dragging/dropping</b> them.")
@@ -203,10 +203,10 @@ block body
                   div(id="network", class="panel-body")
             
           //- Transcript view
-          div(class="panel panel-default panelResizable halfWidthPanel" data-vis="transcript")
+          div(class="panel panel-default panelResizable halfWidthPanel ui-state-default" data-vis="transcript")
             div(class="panel-heading clearfix")
               h4(class="panel-title pull-left")
-                | Transcript
+                | <i class="fa fa-arrows sortableHandle" aria-hidden="true"></i> Transcript
               ul(class="list-inline pull-right")
                 li
                   div(class="dropdown")
@@ -251,10 +251,10 @@ block body
                 div(id="transcript")
 
           //- CNAs row
-          div(class="panel panel-default panelResizable fullWidthPanel" data-vis="cna")
+          div(class="panel panel-default panelResizable fullWidthPanel ui-state-default" data-vis="cna")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
-                    | Copy Number Aberrations
+                    | <i class="fa fa-arrows sortableHandle" aria-hidden="true"></i> Copy Number Aberrations
                   ul(class="list-inline pull-right")
                     li
                       a(class="fa fa-info", title="CNA view description", tabindex="0", data-toggle="popover", data-trigger="hover", data-html="true", data-placement="bottom", data-content="Shows the copy number aberrations surrounding the selected gene (highlighted as red) on the chromosome. The topmost panel shows genes (shown as blocks) distributed in the region. You can click and drag a window in this panel to zoom in and see the details in the middle and bottom panels. The middle and bottom panels show genes and copy number aberration inside the zoom in window you just dragged, respectively. Copy number aberrations are colored by cancer type. Each row represents one sample. You can mouseover copy number aberration to get more detail information.")

--- a/views/view.jade
+++ b/views/view.jade
@@ -96,7 +96,7 @@ block body
     //- MAIN VIEWS
     div(id="main-views")
           //- Aberrations row
-          div(class="panel panel-default panelResizable fullWidthPanel")
+          div(class="panel panel-default panelResizable fullWidthPanel" data-vis="aberration")
             div(class="panel-heading clearfix")
               h4(class="panel-title pull-left")
                 | Aberrations
@@ -147,7 +147,7 @@ block body
               div(id="aberrations", class="panel-body")
 
           //- Heatmap row
-          div(class="panel panel-default panelResizable fullWidthPanel")
+          div(class="panel panel-default panelResizable fullWidthPanel" data-vis="heatmap")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
                     | Heatmap
@@ -174,8 +174,8 @@ block body
                 div(id="collapseHeatmap", class="panel-collapse collapse in")
                   div(id="heatmap", class="panel-body")
 
-          //- Network and transcript row
-          div(class="panel panel-default panelResizable halfWidthPanel")
+          //- Network
+          div(class="panel panel-default panelResizable halfWidthPanel" data-vis="network")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
                     | Network
@@ -203,7 +203,7 @@ block body
                   div(id="network", class="panel-body")
             
           //- Transcript view
-          div(class="panel panel-default panelResizable halfWidthPanel")
+          div(class="panel panel-default panelResizable halfWidthPanel" data-vis="transcript")
             div(class="panel-heading clearfix")
               h4(class="panel-title pull-left")
                 | Transcript
@@ -251,7 +251,7 @@ block body
                 div(id="transcript")
 
           //- CNAs row
-          div(class="panel panel-default panelResizable fullWidthPanel")
+          div(class="panel panel-default panelResizable fullWidthPanel" data-vis="cna")
                 div(class="panel-heading clearfix")
                   h4(class="panel-title pull-left")
                     | Copy Number Aberrations


### PR DESCRIPTION
Uses jQuery UI and vanilla CSS to provide new support for repositionable and resizable MAGI charts. Additionally, the visualizations are now responsive on window resize, which has been a bug since launch.